### PR TITLE
Update CMakeLists.txt files to allow for building on the scc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,47 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_CXX_STANDARD 20)
 
-# Set some basic project attributes
-project (RESPONDREPO)
-
 # When both standard and multithreaded (mt) boost libraries exist, use standard
 set(Boost_USE_MULTITHREADED OFF)
-
-# Only compile api if desired
-option(BUILD_API "enable RESPOND api" OFF)
-
-add_subdirectory(src)
-
-find_package(fmt REQUIRED)
 
 # Only compile tests if desired
 option(BUILD_TESTS "enable RESPOND tests" ON)
 
+# Only compile api if desired
+option(BUILD_API "enable RESPOND api" OFF)
+
+# used to fetch git repository dependencies
+include(FetchContent)
+# download fmt
+FetchContent_Declare(
+  fmt
+  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+  GIT_TAG 9.1.0
+)
+FetchContent_MakeAvailable(fmt)
+
+# Set some basic project attributes
+project (RESPONDREPO)
+
+add_subdirectory(src)
 if (BUILD_TESTS)
-  find_package(GTest REQUIRED)
+  # download gtest/gmock
+  FetchContent_Declare(
+    gtest
+    GIT_REPOSITORY https://github.com/google/googletest
+    GIT_TAG 15460959cbbfa20e66ef0b5ab497367e47fc0a04
+  )
+  FetchContent_MakeAvailable(GTest)
   add_subdirectory(test)
 endif()
 
 if (BUILD_API)
-  find_package(crow REQUIRED)
+  FetchContent_Declare(
+    Crow
+    GIT_REPOSITORY https://github.com/CrowCpp/Crow
+    GIT_TAG master
+    FIND_PACKAGE_ARGS
+  )
+  FetchContent_MakeAvailable(Crow)
   add_subdirectory(api)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,6 @@ project (
 
 include(GNUInstallDirs)
 
-find_package(fmt REQUIRED)
-
 find_package(Eigen3 3.4 REQUIRED)
 
 add_subdirectory(model)

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -7,9 +7,6 @@ find_package(Boost REQUIRED COMPONENTS
   program_options
 )
 
-# Find fmt
-find_package(fmt REQUIRED)
-
 # Find Eigen
 find_package (Eigen3 3.4 REQUIRED)
 

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -7,9 +7,6 @@ set (CMAKE_CXX_STANDARD 20)
 # Find Eigen
 find_package (Eigen3 3.4 REQUIRED)
 
-# Find fmt
-find_package(fmt REQUIRED)
-
 # Find Boost
 find_package(Boost REQUIRED COMPONENTS log_setup log)
 


### PR DESCRIPTION
Changes calls to `find_package()` to using FetchContent for GTest, Crow, and fmt in the build process.