### PR TITLE
Change output directory path to match the input directory.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,8 +35,8 @@ int main(int argc, char **argv) {
     }
 
     for (int i = std::stoi(argv[2]); i < std::stoi(argv[3]); i++) {
-        std::string inputDir = argv[1];
-        inputDir += "input_set" + std::to_string(i);
+        std::string inputDir = argv[1] + '/';
+        inputDir += "input" + std::to_string(i);
         Data::DataLoader inputs(inputDir);
         inputs.loadInitialSample("init_cohort.csv");
         inputs.loadEnteringSamples("entering_cohort.csv", "No_Treatment",
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
         std::vector<std::vector<std::string>> demographics =
             inputs.getConfiguration().getDemographicCombosVecOfVec();
 
-        std::string outputDir = inputDir + "/output" + std::to_string(i);
+        std::string outputDir = inputDir + "output" + std::to_string(i);
         Data::DataWriter writer(outputDir, inputs.getInterventions(),
                                 inputs.getOUDStates(), demographics);
 


### PR DESCRIPTION
Fixes #16, with additional context provided in #21.

Specifically, landing on a structure as in
```
example-project
├── base-case
│   ├── input1
│   ├── input2
│   ├── input3
│   ├── output1
│   ├── output2
│   └── output3
└── experimental-case
    ├── input1
    ├── input2
    ├── input3
    ├── output1
    ├── output2
    └── output3
```