### PR TITLE
Hotfix cycletimestep

### DIFF
--- a/src/data/Configuration.cpp
+++ b/src/data/Configuration.cpp
@@ -222,8 +222,18 @@ namespace Data {
         return this->ptree.get<double>("cost.discount_rate");
     }
 
-    int Configuration::getCostUtilityOutputTimesteps() {
-        return this->ptree.get<int>("cost.cost_utility_output_timesteps");
+    std::vector<int> Configuration::getCostUtilityOutputTimesteps() {
+        std::vector<int> result;
+        std::string res =
+            this->ptree.get<std::string>("cost.cost_utility_output_timesteps");
+        ASSERTM(!res.empty(), "Cost Utility Timesteps Successfully Provided.");
+
+        std::vector<int> resVec = this->parseString2VectorOfInts(res);
+        for (int r : resVec) {
+            result.push_back(r);
+        }
+
+        return result;
     }
 
     bool Configuration::getCostCategoryOutputs() {

--- a/src/data/CostLoader.cpp
+++ b/src/data/CostLoader.cpp
@@ -218,7 +218,8 @@ namespace Data {
         if (this->costSwitch) {
             this->costPerspectives = this->Config.getCostPerspectives();
             this->discountRate = this->Config.getDiscountRate();
-            this->reportingInterval = this->Config.getCostUtilityOutputTimesteps();
+            this->costUtilityOutputTimesteps =
+                this->Config.getCostUtilityOutputTimesteps();
             this->costCategoryOutputs = this->Config.getCostCategoryOutputs();
         }
     }

--- a/src/data/DataLoader.cpp
+++ b/src/data/DataLoader.cpp
@@ -766,7 +766,7 @@ namespace Data {
         if (this->costSwitch) {
             this->costPerspectives = this->Config.getCostPerspectives();
             this->discountRate = this->Config.getDiscountRate();
-            this->reportingInterval =
+            this->costUtilityOutputTimesteps =
                 this->Config.getCostUtilityOutputTimesteps();
             this->costCategoryOutputs = this->Config.getCostCategoryOutputs();
         }
@@ -786,11 +786,11 @@ namespace Data {
         return this->discountRate;
     }
 
-    int DataLoader::getCostUtilityOutputTimesteps() const {
+    std::vector<int> DataLoader::getCostUtilityOutputTimesteps() const {
         if (!this->costSwitch) {
-            return 0;
+            return {0};
         }
-        return this->reportingInterval;
+        return this->costUtilityOutputTimesteps;
     }
 
     bool DataLoader::getCostCategoryOutputs() const {

--- a/src/data/UtilityLoader.cpp
+++ b/src/data/UtilityLoader.cpp
@@ -101,7 +101,8 @@ namespace Data {
         if (this->costSwitch) {
             this->costPerspectives = this->Config.getCostPerspectives();
             this->discountRate = this->Config.getDiscountRate();
-            this->reportingInterval = this->Config.getCostUtilityOutputTimesteps();
+            this->costUtilityOutputTimesteps =
+                this->Config.getCostUtilityOutputTimesteps();
             this->costCategoryOutputs = this->Config.getCostCategoryOutputs();
         }
     }

--- a/src/data/include/Configuration.hpp
+++ b/src/data/include/Configuration.hpp
@@ -50,7 +50,7 @@ namespace Data {
         virtual bool getCostSwitch() = 0;
         virtual std::vector<std::string> getCostPerspectives() = 0;
         virtual double getDiscountRate() = 0;
-        virtual int getCostUtilityOutputTimesteps() = 0;
+        virtual std::vector<int> getCostUtilityOutputTimesteps() = 0;
         virtual bool getPerInterventionPredictions() = 0;
         virtual bool getGeneralOutputsSwitch() = 0;
         virtual std::vector<int> getGeneralStatsOutputTimesteps() = 0;
@@ -181,7 +181,7 @@ namespace Data {
         double getDiscountRate() override;
         /// @brief
         /// @return
-        int getCostUtilityOutputTimesteps() override;
+        std::vector<int> getCostUtilityOutputTimesteps() override;
         /// @brief
         /// @return
         bool getPerInterventionPredictions() override;

--- a/src/data/include/CostLoader.hpp
+++ b/src/data/include/CostLoader.hpp
@@ -172,7 +172,7 @@ namespace Data {
         bool costSwitch = true;
         std::vector<std::string> costPerspectives;
         double discountRate;
-        int reportingInterval;
+        std::vector<int> costUtilityOutputTimesteps;
         bool costCategoryOutputs;
 
         std::unordered_map<std::string, std::unordered_map<std::string, double>>

--- a/src/data/include/DataLoader.hpp
+++ b/src/data/include/DataLoader.hpp
@@ -130,7 +130,7 @@ namespace Data {
         /// @brief Get the bin size for cost reporting timesteps if cost
         /// analysis is enabled. Otherwise, get 0
         /// @return Integer cost reporting timestep bin size
-        virtual int getCostUtilityOutputTimesteps() const = 0;
+        virtual std::vector<int> getCostUtilityOutputTimesteps() const = 0;
 
         /// @brief Get the user config variable specifying whether the cost
         /// outputs should be broken down by cost perspective. Always returns
@@ -325,7 +325,7 @@ namespace Data {
 
         virtual double getDiscountRate() const;
 
-        virtual int getCostUtilityOutputTimesteps() const;
+        virtual std::vector<int> getCostUtilityOutputTimesteps() const;
 
         virtual bool getCostCategoryOutputs() const;
 
@@ -431,7 +431,7 @@ namespace Data {
         bool costSwitch;
         std::vector<std::string> costPerspectives;
         double discountRate;
-        int reportingInterval;
+        std::vector<int> costUtilityOutputTimesteps;
         bool costCategoryOutputs;
         // output parameters
         bool perInterventionPredictions;

--- a/src/data/include/UtilityLoader.hpp
+++ b/src/data/include/UtilityLoader.hpp
@@ -135,7 +135,7 @@ namespace Data {
         bool costSwitch = true;
         std::vector<std::string> costPerspectives;
         double discountRate;
-        int reportingInterval;
+        std::vector<int> costUtilityOutputTimesteps;
         bool costCategoryOutputs;
 
         /// @brief

--- a/tests/mocks/MockDataLoader.hpp
+++ b/tests/mocks/MockDataLoader.hpp
@@ -55,7 +55,8 @@ public:
 
     MOCK_METHOD(double, getDiscountRate, (), (const, override));
 
-    MOCK_METHOD(int, getCostUtilityOutputTimesteps, (), (const, override));
+    MOCK_METHOD(std::vector<int>, getCostUtilityOutputTimesteps, (),
+                (const, override));
 
     MOCK_METHOD(bool, getCostCategoryOutputs, (), (const, override));
 

--- a/tests/src/DataLoaderTest.cpp
+++ b/tests/src/DataLoaderTest.cpp
@@ -423,7 +423,7 @@ TEST_F(DataLoaderTest, getDiscountRate) {
 
 TEST_F(DataLoaderTest, getCostUtilityOutputTimesteps) {
     Data::DataLoader dl(boost::filesystem::temp_directory_path().string());
-    EXPECT_EQ(dl.getCostUtilityOutputTimesteps(), 52);
+    EXPECT_EQ(dl.getCostUtilityOutputTimesteps()[0], 52);
 }
 
 TEST_F(DataLoaderTest, getCostCategoryOutputs) {


### PR DESCRIPTION
- Hotfix for Removing the Correct Timestep Columns from `block_trans.csv`
- Converted Cost Utility Timestep Outputs to a Vector instead of an int