### PR TITLE
Streamlining build for the BU SCC

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,7 +61,8 @@ done
 
 (
     # change to the top-level git folder
-    cd "$(git rev-parse --show-toplevel)" || exit
+    TOPLEVEL="$(git rev-parse --show-toplevel)"
+    cd "$TOPLEVEL" || exit
     CONANPATH=$(command -v conan)
 
     # install conan, if not found in the current scope
@@ -94,7 +95,10 @@ done
     # detect or install DataManagement
     if [[ ! -d "lib/dminstall" ]]; then
 	git clone git@github.com:SyndemicsLab/DataManagement
-	if ! DataManagement/install.sh "lib/dminstall"; then
+	if ! (
+		cd "DataManagement" || exit 1
+		./install.sh "$TOPLEVEL/lib/dminstall"
+	    ); then
 	    echo "Installing \`DataManagement\` failed."
 	fi
 	rm -rf DataManagement


### PR DESCRIPTION
This PR adds:
- `DataManagement` clone and build, if not already present
- Installing a `conda` environment, if it doesn't exist

There's probably a better way (e.g. checking `hostname`) to check that the host is on the scc than to check if the `module` command exists, but I'm scarred by our past experiences with BU SCC support and don't want to reach out right now...

The `DataManagement` install is probably also worth including in `HEPCESimulationv2` too :eyes:

You can test this PR easily via this convenient one-liner:
```bash
git clone git@github.com:SyndemicsLab/RESPONDSimulationv2 -b "more-build-changes" && (cd RESPONDSimulationv2; scripts/build.sh -pb;) && rm -rf RESPONDSimulationv2
```