### PR TITLE
Remove the print so running doesn't take forever

### DIFF
--- a/src/matrixify/DataLoader.cpp
+++ b/src/matrixify/DataLoader.cpp
@@ -430,7 +430,6 @@ namespace Matrixify {
 
             // fillTime(startTime, timestep, temp, this->fatalOverdoseRates);
         }
-        Matrix3dPrinter::PrintOverTime(this->fatalOverdoseRates, std::cout);
         return this->fatalOverdoseRates;
     }
 


### PR DESCRIPTION
Hotfix to actually run without dumping tons of memory into a file