### PR TITLE
[Hotfix] Copy assignment operator reference to local object error fix

### DIFF
--- a/src/internals/markov_internals.hpp
+++ b/src/internals/markov_internals.hpp
@@ -40,11 +40,10 @@ public:
     }
 
     MarkovImpl &operator=(const MarkovImpl &other) {
-        MarkovImpl temp(GetLoggerName());
-
-        temp.SetTransitions(other.GetTransitions());
-        temp.SetState(other.GetState());
-        return temp;
+        _logger_name = other.GetLoggerName();
+        this->SetTransitions(other.GetTransitions());
+        this->SetState(other.GetState());
+        return *this;
     }
 
     void SetState(const Eigen::VectorXd &state_vector) override {
@@ -74,7 +73,7 @@ public:
     std::string GetLoggerName() const override { return _logger_name; }
 
 private:
-    const std::string _logger_name;
+    std::string _logger_name;
     Eigen::VectorXd _state;
     std::vector<transition> _transitions = {};
     std::map<int, stamper> _stamper_functions;


### PR DESCRIPTION
I had to remove the `const` modifier from `_logger_name` to make this work, since we can't use an initializer list for the copy assignment. Apparently, it's [not worth the agony](https://stackoverflow.com/questions/77857017/copy-assignment-operator-on-object-with-const-member) associated with trying to get this working while maintaining the constant qualifier here.