### PR TITLE
[Hotfix] Removing the unnecessary config command

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,7 @@ jobs:
                   EIGEN3_INCLUDE_DIR: ${{ steps.install-eigen3.outputs.EIGEN3_INCLUDE_DIR }}
                   EIGEN3_DIR: ${{ steps.install-eigen3.outputs.EIGEN3_DIR}}
               run: >
-                  cmake --config --preset release-linux-shared-config
+                  cmake --preset release-linux-shared-config
 
             - name: Generate Doxygen Documentation
               run: doxygen Doxyfile


### PR DESCRIPTION
## What does this PR do?

Provides a hotfix for the documentation deploy workflow. The workflow had an error with a `--config` tag in the command line that doesn't work with CMake.

## What Wrike task is this associated with?

NA

## Checklist before merging

- [x] If adding a core feature, I've added related tests.
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
