### PR TITLE
[Hotfix] Adding mortality and fod tracking

### DIFF
--- a/include/respond/markov.hpp
+++ b/include/respond/markov.hpp
@@ -24,7 +24,8 @@ namespace respond {
 
 /// @brief type for a general function to apply a transition to the model state.
 using transition_function = std::function<Eigen::VectorXd(
-    Eigen::VectorXd &, const std::vector<Eigen::MatrixXd> &, HistoryStamp &)>;
+    const Eigen::VectorXd &, const std::vector<Eigen::MatrixXd> &,
+    HistoryStamp &)>;
 
 /// @brief The pair of functions and transition matrices.
 using transition = std::pair<transition_function, std::vector<Eigen::MatrixXd>>;

--- a/include/respond/markov.hpp
+++ b/include/respond/markov.hpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-10-16                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef RESPOND_MARKOV_HPP_
@@ -22,13 +22,9 @@
 
 namespace respond {
 
-/// @brief type for a general function to apply a stamp within a model step.
-using stamper =
-    std::function<void(HistoryStamp &, Eigen::VectorXd, Eigen::VectorXd)>;
-
 /// @brief type for a general function to apply a transition to the model state.
 using transition_function = std::function<Eigen::VectorXd(
-    Eigen::VectorXd &, const std::vector<Eigen::MatrixXd> &)>;
+    Eigen::VectorXd &, const std::vector<Eigen::MatrixXd> &, HistoryStamp &)>;
 
 /// @brief The pair of functions and transition matrices.
 using transition = std::pair<transition_function, std::vector<Eigen::MatrixXd>>;

--- a/include/respond/respond.hpp
+++ b/include/respond/respond.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-01-26                                                  //
+// Last Modified: 2026-01-27                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -135,7 +135,8 @@ Eigen::VectorXd Overdose(const Eigen::VectorXd &state,
     return new_state;
 }
 
-/// @brief A function to model the mortality within the SUD community.
+/// @brief A function to model the background mortality within the SUD
+/// community.
 /// @param state The model state vector.
 /// @param transition A vector of size 1 containing the transition matrix for
 /// background mortalities.

--- a/include/respond/respond.hpp
+++ b/include/respond/respond.hpp
@@ -147,9 +147,9 @@ Eigen::VectorXd Mortality(const Eigen::VectorXd &state,
         throw std::runtime_error(
             "Mortality Transitions must have 1 Transition Matrix.");
     }
-    auto deaths = transition[0] * state; // calculate the deaths
-    stamp.background_mortality = deaths; // store the deaths
-    auto new_state = state - deaths;     // remove deaths from state
+    auto deaths = state.cwiseProduct(transition[0]); // calculate the deaths
+    stamp.background_mortality = deaths;             // store the deaths
+    auto new_state = state - deaths;                 // remove deaths from state
     return new_state;
 }
 } // namespace respond

--- a/include/respond/types.hpp
+++ b/include/respond/types.hpp
@@ -37,6 +37,7 @@ struct HistoryStamp {
     Eigen::VectorXd total_overdoses = Eigen::VectorXd::Zero(0);
     Eigen::VectorXd fatal_overdoses = Eigen::VectorXd::Zero(0);
     Eigen::VectorXd intervention_admissions = Eigen::VectorXd::Zero(0);
+    Eigen::VectorXd background_mortality = Eigen::VectorXd::Zero(0);
 };
 
 /// @brief A map of the timestep to the HistoryStamp.

--- a/include/respond/types.hpp
+++ b/include/respond/types.hpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-08-05                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef RESPOND_DATATYPES_HPP_
@@ -34,7 +34,8 @@ template <typename T> using StringUOMap = std::unordered_map<std::string, T>;
 /// @brief Struct grouping together matrices containing run history
 struct HistoryStamp {
     Eigen::VectorXd state = Eigen::VectorXd::Zero(0);
-    Eigen::VectorXd overdoses = Eigen::VectorXd::Zero(0);
+    Eigen::VectorXd total_overdoses = Eigen::VectorXd::Zero(0);
+    Eigen::VectorXd fatal_overdoses = Eigen::VectorXd::Zero(0);
     Eigen::VectorXd intervention_admissions = Eigen::VectorXd::Zero(0);
 };
 

--- a/src/internals/markov_internals.hpp
+++ b/src/internals/markov_internals.hpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-10-16                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 #ifndef RESPOND_MARKOVINTERNALS_HPP_
 #define RESPOND_MARKOVINTERNALS_HPP_
@@ -75,7 +75,6 @@ private:
     std::string _logger_name;
     Eigen::VectorXd _state;
     std::vector<transition> _transitions = {};
-    std::map<int, stamper> _stamper_functions;
     int _time = 0;
     HistoryOverTime _history = {};
 
@@ -88,33 +87,14 @@ private:
 
     void ResetHistory() { _history.clear(); }
 
-    void ResetStamperFunctions() { _stamper_functions.clear(); }
-
-    void WriteFirstHistoryStamp() {
+    void RecordInitialHistoryStamp() {
         ResetHistory();
         HistoryStamp stamp;
         stamp.state = _state;
         stamp.intervention_admissions = Eigen::VectorXd::Zero(_state.size());
-        stamp.overdoses = Eigen::VectorXd::Zero(_state.size());
+        stamp.total_overdoses = Eigen::VectorXd::Zero(_state.size());
+        stamp.fatal_overdoses = Eigen::VectorXd::Zero(_state.size());
         _history[0] = stamp;
-    }
-
-    void WriteDefaultStamperFunctions() {
-        ResetStamperFunctions();
-        // Setup the Stamper Functions
-        _stamper_functions[2] = [](HistoryStamp &hs, Eigen::VectorXd state,
-                                   Eigen::VectorXd moud_movements) {
-            Eigen::VectorXd admissions = state - moud_movements;
-            Eigen::VectorXd mat = Eigen::VectorXd::Zero(admissions.size());
-
-            admissions = admissions.cwiseMax(mat);
-            hs.intervention_admissions = admissions;
-        };
-
-        _stamper_functions[3] = [](HistoryStamp &hs, Eigen::VectorXd state,
-                                   Eigen::VectorXd od_movements) {
-            hs.overdoses = od_movements;
-        };
     }
 };
 } // namespace respond

--- a/src/internals/markov_internals.hpp
+++ b/src/internals/markov_internals.hpp
@@ -94,6 +94,7 @@ private:
         stamp.intervention_admissions = Eigen::VectorXd::Zero(_state.size());
         stamp.total_overdoses = Eigen::VectorXd::Zero(_state.size());
         stamp.fatal_overdoses = Eigen::VectorXd::Zero(_state.size());
+        stamp.background_mortality = Eigen::VectorXd::Zero(_state.size());
         _history[0] = stamp;
     }
 };

--- a/src/markov.cpp
+++ b/src/markov.cpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-07-07                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-10-16                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "internals/markov_internals.hpp"
@@ -29,9 +29,9 @@ void MarkovImpl::Run(const int &num_steps) {
     ResetTime();
 
     // All histories now start with t = 0
-    WriteFirstHistoryStamp();
+    RecordInitialHistoryStamp();
 
-    WriteDefaultStamperFunctions();
+    // WriteDefaultStamperFunctions();
 
     while (_time < num_steps) {
         HistoryStamp stamp;
@@ -65,12 +65,7 @@ void MarkovImpl::LogDebugPoint(const std::string &message,
 void MarkovImpl::Step(HistoryStamp &hs) {
     for (int i = 0; i < _transitions.size(); ++i) {
         transition t = _transitions[i];
-        auto temp = (t.first)(_state, t.second);
-        auto it = _stamper_functions.find(i);
-        if (it != _stamper_functions.end()) {
-            it->second(hs, _state, temp);
-        }
-        _state = temp;
+        _state = (t.first)(_state, t.second, hs);
     }
 }
 

--- a/tests/markov_test.cpp
+++ b/tests/markov_test.cpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-06-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-10-16                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <respond/markov.hpp>
@@ -34,7 +34,7 @@ TEST_F(MarkovTest, ZeroDuration) {
     auto expected = Eigen::VectorXd::Zero(0);
     EXPECT_TRUE(results[0].state.isApprox(expected));
     EXPECT_TRUE(results[0].intervention_admissions.isApprox(expected));
-    EXPECT_TRUE(results[0].overdoses.isApprox(expected));
+    EXPECT_TRUE(results[0].total_overdoses.isApprox(expected));
 }
 
 TEST_F(MarkovTest, SingleStep) {
@@ -42,9 +42,8 @@ TEST_F(MarkovTest, SingleStep) {
     markov->SetState(Eigen::VectorXd::Ones(5));
 
     transition t = {[](Eigen::VectorXd &state,
-                       const std::vector<Eigen::MatrixXd> &transitions) {
-                        return state + transitions[0];
-                    },
+                       const std::vector<Eigen::MatrixXd> &transitions,
+                       HistoryStamp &hs) { return state + transitions[0]; },
                     {Eigen::VectorXd::Ones(5)}};
     markov->SetTransitions({t});
 
@@ -59,9 +58,8 @@ TEST_F(MarkovTest, MultipleTransitions) {
     markov->SetState(Eigen::VectorXd::Ones(5));
 
     transition t = {[](Eigen::VectorXd &state,
-                       const std::vector<Eigen::MatrixXd> &transitions) {
-                        return state + transitions[0];
-                    },
+                       const std::vector<Eigen::MatrixXd> &transitions,
+                       HistoryStamp &hs) { return state + transitions[0]; },
                     {Eigen::VectorXd::Ones(5)}};
     markov->SetTransitions({t, t, t, t, t});
 
@@ -69,10 +67,6 @@ TEST_F(MarkovTest, MultipleTransitions) {
     auto results = markov->GetRunResults();
 
     EXPECT_TRUE(results[1].state.isApprox(Eigen::VectorXd::Constant(5, 6.0)));
-    EXPECT_TRUE(results[1].intervention_admissions.isApprox(
-        Eigen::VectorXd::Constant(5, 0.0)));
-    EXPECT_TRUE(
-        results[1].overdoses.isApprox(Eigen::VectorXd::Constant(5, 5.0)));
 }
 
 TEST_F(MarkovTest, CopyConstructor) {

--- a/tests/markov_test.cpp
+++ b/tests/markov_test.cpp
@@ -41,7 +41,7 @@ TEST_F(MarkovTest, SingleStep) {
     auto markov = Markov::Create("test_logger");
     markov->SetState(Eigen::VectorXd::Ones(5));
 
-    transition t = {[](Eigen::VectorXd &state,
+    transition t = {[](const Eigen::VectorXd &state,
                        const std::vector<Eigen::MatrixXd> &transitions,
                        HistoryStamp &hs) { return state + transitions[0]; },
                     {Eigen::VectorXd::Ones(5)}};
@@ -57,7 +57,7 @@ TEST_F(MarkovTest, MultipleTransitions) {
     auto markov = Markov::Create("test_logger");
     markov->SetState(Eigen::VectorXd::Ones(5));
 
-    transition t = {[](Eigen::VectorXd &state,
+    transition t = {[](const Eigen::VectorXd &state,
                        const std::vector<Eigen::MatrixXd> &transitions,
                        HistoryStamp &hs) { return state + transitions[0]; },
                     {Eigen::VectorXd::Ones(5)}};

--- a/tests/respond_test.cpp
+++ b/tests/respond_test.cpp
@@ -103,20 +103,15 @@ TEST_F(RespondTest, Overdose_Function) {
 }
 
 TEST_F(RespondTest, Mortality_Function) {
-    Eigen::MatrixXd t(6, 6);
+    Eigen::VectorXd t(6);
     // clang-format off
-    t << 1.0, 0.0, 0.0, 0.0, 0.0, 0.0,
-         0.0, 1.0, 0.0, 0.0, 0.0, 0.0,
-         0.0, 0.0, 0.9, 0.0, 0.0, 0.0,
-         0.0, 0.0, 0.0, 0.2, 0.0, 0.0,
-         0.0, 0.0, 0.1, 0.0, 1.0, 0.0,
-         0.0, 0.0, 0.0, 0.8, 0.0, 1.0;
+    t << 1.0, 1.0, 0.9, 0.2, 0.0, 0.0;
     // clang-format on
     transition_matrices.push_back(t);
 
     auto result = Mortality(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
-    expected << 1.0, 1.0, 0.9, 0.2, 1.1, 1.8;
+    expected << 0.0, 0.0, 0.1, 0.8, 1.0, 1.0;
 
     EXPECT_TRUE(result.isApprox(expected));
 }

--- a/tests/respond_test.cpp
+++ b/tests/respond_test.cpp
@@ -4,10 +4,10 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2025-12-01                                                  //
+// Last Modified: 2026-01-26                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
-// Copyright (c) 2025 Syndemics Lab at Boston Medical Center                  //
+// Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <respond/respond.hpp>
@@ -25,6 +25,7 @@ class RespondTest : public ::testing::Test {
 protected:
     Eigen::VectorXd state;
     std::vector<Eigen::MatrixXd> transition_matrices;
+    HistoryStamp stamp;
     void SetUp() override {
         state = Eigen::VectorXd::Ones(6);
         transition_matrices.clear();
@@ -38,7 +39,7 @@ TEST_F(RespondTest, Migration_Function) {
     t << -1, 0, 1, 0, 0, 0;
     transition_matrices.push_back(t);
 
-    auto result = Migration(state, transition_matrices);
+    auto result = Migration(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
     expected << 0, 1, 2, 1, 1, 1;
 
@@ -58,7 +59,7 @@ TEST_F(RespondTest, Behavior_Function) {
     // clang-format on
     transition_matrices.push_back(t);
 
-    auto result = Behavior(state, transition_matrices);
+    auto result = Behavior(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
     expected << 1.0, 1.0, 1.1, 0.9, 1.0, 1.0;
 
@@ -79,7 +80,7 @@ TEST_F(RespondTest, Intervention_Function) {
 
     transition_matrices.push_back(t1);
 
-    auto result = Intervention(state, transition_matrices);
+    auto result = Intervention(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
     expected << 1.0, 1.0, 0.3, 1.7, 1.0, 1.0;
     EXPECT_TRUE(result.isApprox(expected));
@@ -94,12 +95,11 @@ TEST_F(RespondTest, Overdose_Function) {
     transition_matrices.push_back(t1);
     transition_matrices.push_back(t2);
 
-    auto result = Overdose(state, transition_matrices);
+    auto result = Overdose(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
-    expected << 1.0, 1.0, 0.9, 0.95, 1.1, 1.05;
+    expected << 1.0, 1.0, 0.9, 0.95, 1.0, 1.0;
 
-    EXPECT_TRUE(state.isApprox(expected));
-    EXPECT_TRUE(result.isApprox(t1));
+    EXPECT_TRUE(result.isApprox(expected));
 }
 
 TEST_F(RespondTest, Mortality_Function) {
@@ -114,7 +114,7 @@ TEST_F(RespondTest, Mortality_Function) {
     // clang-format on
     transition_matrices.push_back(t);
 
-    auto result = Mortality(state, transition_matrices);
+    auto result = Mortality(state, transition_matrices, stamp);
     Eigen::VectorXd expected(6);
     expected << 1.0, 1.0, 0.9, 0.2, 1.1, 1.8;
 


### PR DESCRIPTION
## What does this PR do?

This PR focuses on adding in the tracking through the HistoryStamp for the fatal overdose and background mortality values.

## What Wrike task is this associated with?

N/A

## Checklist before merging

- [x] If adding a core feature, I've added related tests. (We might want more tests here, but I just fixed the old ones)
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
