### PR TITLE
Hotfix/duration

### DIFF
--- a/include/respond/model.hpp
+++ b/include/respond/model.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-09                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -41,6 +41,8 @@ public:
     // return const & to limit to observation of the state. Need copy ability of
     // History, but let that be the History's responsibility
     virtual std::map<std::string, History> GetHistories() const = 0;
+
+    virtual void CreateDefaultHistories() = 0;
 
     virtual void SetHistories(const std::map<std::string, History> &h) = 0;
     // getter for model name

--- a/include/respond/simulation.hpp
+++ b/include/respond/simulation.hpp
@@ -33,12 +33,10 @@ public:
     /// @brief The core function to run the simulation. Runs all models
     /// associated with the simulation.
     /// @param duration The number of steps to take for each model.
-    void Run(const int &duration) {
-        // for (int i = 0; i < duration; ++i) {
+    void Run() {
         for (const auto &model : _models) {
             model->RunTransitions();
         }
-        // }
     }
 
     void AddModel(const std::unique_ptr<Model> &model) {
@@ -85,27 +83,6 @@ public:
                                                          kv.first};
                 ret.push_back(p);
             }
-        }
-        return ret;
-    }
-
-    /// @brief The default histories are:
-    ///     1. State
-    ///     2. Total Overdoses
-    ///     3. Fatal Overdoses
-    ///     4. Intervention Admissions
-    ///     5. Background Mortality
-    /// @return A vector of the default history objects.
-    static std::map<std::string, History>
-    CreateDefaultHistories(const std::string &log_name) {
-        std::vector<std::string> names = {
-            "state", "total_overdose", "fatal_overdose",
-            "intervention_admission", "background_death"};
-
-        std::map<std::string, History> ret;
-        for (const auto &n : names) {
-            History h(n, log_name);
-            ret[n] = h;
         }
         return ret;
     }

--- a/include/respond/simulation.hpp
+++ b/include/respond/simulation.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-10                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -34,11 +34,11 @@ public:
     /// associated with the simulation.
     /// @param duration The number of steps to take for each model.
     void Run(const int &duration) {
-        for (int i = 0; i < duration; ++i) {
-            for (const auto &model : _models) {
-                model->RunTransitions();
-            }
+        // for (int i = 0; i < duration; ++i) {
+        for (const auto &model : _models) {
+            model->RunTransitions();
         }
+        // }
     }
 
     void AddModel(const std::unique_ptr<Model> &model) {

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-05                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -27,6 +27,10 @@ BackgroundDeath::Execute(const Eigen::VectorXd &state,
         state.cwiseProduct(GetTransitionMatrices()[0]); // calculate the deaths
     if (h.find("background_death") != h.end()) {
         h["background_death"].AddState(deaths);
+    }
+    if (!(state.array() >= deaths.array()).all()) {
+        std::runtime_error(
+            "The state is not larger than the estimated background deaths!");
     }
     auto new_state = state - deaths; // remove deaths from state
     return new_state;

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -33,6 +33,10 @@ BackgroundDeath::Execute(const Eigen::VectorXd &state,
             "The state is not larger than the estimated background deaths!");
     }
     auto new_state = state - deaths; // remove deaths from state
+
+    if (h.find("background_death") != h.end()) {
+        h["state"].AddState(new_state);
+    }
     return new_state;
 }
 

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -156,6 +156,7 @@ private:
         histories["total_overdose"].AddState(Eigen::VectorXd::Zero(size));
         histories["fatal_overdose"].AddState(Eigen::VectorXd::Zero(size));
         histories["background_death"].AddState(Eigen::VectorXd::Zero(size));
+        SetHistories(histories);
     }
 };
 } // namespace respond

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -105,9 +105,6 @@ public:
         for (const auto &t : _transition_vector) {
             SetState(t->Execute(GetState(), histories));
         }
-        if (histories.find("state") != histories.end()) {
-            histories["state"].AddState(GetState());
-        }
         SetHistories(histories);
     }
     // assume ownership of the Transition

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-10                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -78,8 +78,29 @@ public:
         return _transition_vector;
     }
 
+    /// @brief The default histories are:
+    ///     1. State
+    ///     2. Total Overdoses
+    ///     3. Fatal Overdoses
+    ///     4. Intervention Admissions
+    ///     5. Background Mortality
+    /// @return A vector of the default history objects.
+    void CreateDefaultHistories() override {
+        std::vector<std::string> names = {
+            "state", "total_overdose", "fatal_overdose",
+            "intervention_admission", "background_death"};
+
+        std::map<std::string, History> ret;
+        for (const auto &n : names) {
+            History h(n, GetLogName());
+            ret[n] = h;
+        }
+        SetHistories(ret);
+    }
+
     // manipulate the state vector
     void RunTransitions() override {
+        SetupHistory();
         auto histories = GetHistories();
         for (const auto &t : _transition_vector) {
             SetState(t->Execute(GetState(), histories));
@@ -123,6 +144,22 @@ private:
     std::string _name;
     std::string _log_name;
     std::map<std::string, History> _histories;
+
+    void SetupHistory() {
+        auto histories = GetHistories();
+        if (histories.empty()) {
+            CreateDefaultHistories();
+            histories = GetHistories();
+        }
+        histories["state"].AddState(GetState());
+        auto size = GetState().size();
+
+        histories["intervention_admission"].AddState(
+            Eigen::VectorXd::Zero(size));
+        histories["total_overdose"].AddState(Eigen::VectorXd::Zero(size));
+        histories["fatal_overdose"].AddState(Eigen::VectorXd::Zero(size));
+        histories["background_death"].AddState(Eigen::VectorXd::Zero(size));
+    }
 };
 } // namespace respond
 

--- a/src/migration.cpp
+++ b/src/migration.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-05                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -26,8 +26,10 @@ Eigen::VectorXd Migration::Execute(const Eigen::VectorXd &state,
         throw std::runtime_error("Unable to add Migration Transition Vector to "
                                  "State Vector, mismatched sizes.");
     }
-    auto new_state = state + GetTransitionMatrices()[0];
-    return new_state;
+    auto subtracted = state + GetTransitionMatrices()[0];
+    auto zero_stop = subtracted.array().max(
+        Eigen::VectorXd::Zero(subtracted.size()).array());
+    return zero_stop;
 }
 
 std::unique_ptr<Transition> Migration::Create(const std::string &name,

--- a/src/overdose.cpp
+++ b/src/overdose.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-05                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -41,6 +41,10 @@ Eigen::VectorXd Overdose::Execute(const Eigen::VectorXd &state,
     auto fods = overdoses.cwiseProduct(GetTransitionMatrices()[1]); // negatives
     if (h.find("fatal_overdose") != h.end()) {
         h["fatal_overdose"].AddState(fods);
+    }
+    if (!(state.array() >= fods.array()).all()) {
+        std::runtime_error(
+            "The state is not larger than the estimated fatal overdoses!");
     }
     auto new_state = state - fods; // remove fods from state
     return new_state;

--- a/tests/integration/respond_test.cpp
+++ b/tests/integration/respond_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-02-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -119,11 +119,13 @@ TEST_F(RespondTest, RunSimulationOneStep) {
     }
 
     auto state_history = mm_histories.at("state");
-    ASSERT_EQ(state_history.size(), 1);
+    // 2 because it carries the initial state and 1 step
+    ASSERT_EQ(state_history.size(), 2);
 
     Eigen::Vector3d final_state;
+    ASSERT_TRUE(state_history[0].isApprox(init_state));
     final_state << 0.76715528791564891, 0.72320370216816077, 1.037712429738102;
-    ASSERT_TRUE(state_history[0].isApprox(final_state));
+    ASSERT_TRUE(state_history[1].isApprox(final_state));
 }
 
 TEST_F(RespondTest, CreateDefaultHistories) {

--- a/tests/integration/respond_test.cpp
+++ b/tests/integration/respond_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-10                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -86,7 +86,7 @@ TEST_F(RespondTest, RunTransitionsInModel) {
 }
 
 TEST_F(RespondTest, RunSimulationOneStep) {
-    markov->SetHistories(Simulation::CreateDefaultHistories("test_logger"));
+    markov->CreateDefaultHistories();
 
     markov->SetState(init_state);
 
@@ -108,7 +108,7 @@ TEST_F(RespondTest, RunSimulationOneStep) {
 
     Simulation sim("test_logger");
     sim.AddModel(markov);
-    sim.Run(1);
+    sim.Run();
 
     auto histories = sim.GetModelHistories();
     ASSERT_EQ(histories.size(), 1);
@@ -124,6 +124,21 @@ TEST_F(RespondTest, RunSimulationOneStep) {
     Eigen::Vector3d final_state;
     final_state << 0.76715528791564891, 0.72320370216816077, 1.037712429738102;
     ASSERT_TRUE(state_history[0].isApprox(final_state));
+}
+
+TEST_F(RespondTest, CreateDefaultHistories) {
+    std::vector<std::string> expected = {
+        "state", "total_overdose", "fatal_overdose", "intervention_admission",
+        "background_death"};
+
+    std::sort(expected.begin(), expected.end());
+
+    markov->CreateDefaultHistories();
+    std::vector<std::string> results;
+    for (const auto &kv : markov->GetHistories()) {
+        results.push_back(kv.first);
+    }
+    ASSERT_EQ(results, expected);
 }
 
 } // namespace testing

--- a/tests/mocks/model_mock.hpp
+++ b/tests/mocks/model_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-09                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -45,6 +45,7 @@ public:
     MOCK_METHOD(std::string, GetModelName, (), (const, override));
     MOCK_METHOD(std::string, GetLogName, (), (const, override));
     MOCK_METHOD((std::unique_ptr<Model>), clone, (), (const, override));
+    MOCK_METHOD(void, CreateDefaultHistories, (), (override));
 };
 } // namespace testing
 } // namespace respond

--- a/tests/unit/simulation_test.cpp
+++ b/tests/unit/simulation_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-10                                                  //
+// Last Modified: 2026-02-12                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -133,20 +133,5 @@ TEST_F(SimulationTest, GetHistoryNames) {
     ASSERT_EQ(s.GetModelHistoryNames(), expected);
 }
 
-TEST_F(SimulationTest, CreateDefaultHistories) {
-    std::vector<std::string> expected = {
-        "state", "total_overdose", "fatal_overdose", "intervention_admission",
-        "background_death"};
-
-    std::sort(expected.begin(), expected.end());
-
-    Simulation s;
-    auto defaults = s.CreateDefaultHistories("test_logger");
-    std::vector<std::string> results;
-    for (const auto &kv : defaults) {
-        results.push_back(kv.first);
-    }
-    ASSERT_EQ(results, expected);
-}
 } // namespace testing
 } // namespace respond


### PR DESCRIPTION
## What does this PR do?

Four key updates:
1. Removed Duration from simulation run function
2. Added initial history setup
3. Moved static `CreateDefaultHistories` method into a non-static model function

## What Wrike task is this associated with?

## Checklist before merging

- [x] If adding a core feature, I've added related tests.
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
