### PR TITLE
[Hotfix] Eigen Refs

### DIFF
--- a/include/respond/cost_effectiveness.hpp
+++ b/include/respond/cost_effectiveness.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -27,7 +27,7 @@ namespace respond {
 /// @param N Number of weeks to discount over.
 /// @param isDiscrete Whether the discount is a discrete or continuous discount.
 /// @return A matrix with the discounted data.
-inline Eigen::VectorXd Discount(const Eigen::VectorXd &data,
+inline Eigen::VectorXd Discount(const Eigen::Ref<const Eigen::VectorXd> &data,
                                 double discount_rate, int week,
                                 bool is_discrete = true,
                                 double total_weeks = 52.0) {
@@ -41,8 +41,9 @@ inline Eigen::VectorXd Discount(const Eigen::VectorXd &data,
 /// @param state The state matrix.
 /// @param multiplier The multiplying matrix.
 /// @return state cwise multiplied by the multiplying matrix.
-inline Eigen::VectorXd CwiseProduct(const Eigen::VectorXd &state,
-                                    const Eigen::VectorXd &multiplier) {
+inline Eigen::VectorXd
+CwiseProduct(const Eigen::Ref<const Eigen::VectorXd> &state,
+             const Eigen::Ref<const Eigen::VectorXd> &multiplier) {
     return state.cwiseProduct(multiplier);
 }
 
@@ -50,8 +51,9 @@ inline Eigen::VectorXd CwiseProduct(const Eigen::VectorXd &state,
 /// @param state The state matrix.
 /// @param multiplier The multiplying matrix.
 /// @return state cwise multiplied by the multiplying matrix.
-inline Eigen::VectorXd CwiseMin(const Eigen::VectorXd &state,
-                                const Eigen::VectorXd &multiplier) {
+inline Eigen::VectorXd
+CwiseMin(const Eigen::Ref<const Eigen::VectorXd> &state,
+         const Eigen::Ref<const Eigen::VectorXd> &multiplier) {
     return state.cwiseMin(multiplier);
 }
 

--- a/include/respond/history.hpp
+++ b/include/respond/history.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-05-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -206,7 +206,8 @@ public:
     /// automatic next timestep). If timestep is negative, the next sequential
     /// timestep is used automatically. If timestep already exists, it is
     /// considered invalid but is currently overwritten.
-    void AddState(const Eigen::VectorXd &state, int timestep = -1) {
+    void AddState(const Eigen::Ref<const Eigen::VectorXd> &state,
+                  int timestep = -1) {
         if (timestep < 0) {
             timestep = GetNextTimestep();
         }
@@ -227,13 +228,14 @@ public:
     /// @brief Records a snapshot value at a concrete timestep.
     /// @param state The snapshot value to record.
     /// @param timestep The simulation timestep for this snapshot.
-    void RecordSnapshot(const Eigen::VectorXd &state, int timestep) {
+    void RecordSnapshot(const Eigen::Ref<const Eigen::VectorXd> &state,
+                        int timestep) {
         AddState(state, timestep);
     }
 
     /// @brief Adds a contribution to an accumulated history.
     /// @param state The per-step contribution to accumulate.
-    void AccumulateState(const Eigen::VectorXd &state) {
+    void AccumulateState(const Eigen::Ref<const Eigen::VectorXd> &state) {
         if (_mode != HistoryMode::Accumulated) {
             AddState(state);
             return;

--- a/include/respond/model.hpp
+++ b/include/respond/model.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -33,7 +33,7 @@ public:
 
     /// @brief Sets the current state of the model.
     /// @param state The state vector to set. A copy is made internally.
-    virtual void SetState(const Eigen::VectorXd &state) = 0;
+    virtual void SetState(const Eigen::Ref<const Eigen::VectorXd> &state) = 0;
 
     /// @brief Retrieves the current state of the model.
     /// @return A copy of the current state vector (limited to observation).

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-02                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-09                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -40,13 +40,14 @@ public:
     /// transition).
     /// @return The resulting state vector after applying this transition.
     virtual Eigen::VectorXd
-    Execute(const Eigen::VectorXd &s,
+    Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
             std::map<std::string, History> &h) const = 0;
 
     /// @brief Adds a transformation matrix to this transition.
     /// The matrix is stored for use during Execute() calls.
     /// @param m The transition matrix to add (not modified by this transition).
-    virtual void AddTransitionMatrix(const Eigen::MatrixXd &m) = 0;
+    virtual void
+    AddTransitionMatrix(const Eigen::Ref<const Eigen::MatrixXd> &m) = 0;
 
     /// @brief Retrieves the name/type of this transition.
     /// @return The transition's identifier as a string.

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -20,7 +20,7 @@
 
 namespace respond {
 Eigen::VectorXd
-BackgroundDeath::Execute(const Eigen::VectorXd &state,
+BackgroundDeath::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
                          std::map<std::string, History> &h) const {
     if (GetTransitionMatrices().size() != 1) {
         std::string error_msg =

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-05                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -19,8 +19,9 @@
 #include <spdlog/spdlog.h>
 
 namespace respond {
-Eigen::VectorXd Behavior::Execute(const Eigen::VectorXd &state,
-                                  std::map<std::string, History> &h) const {
+Eigen::VectorXd
+Behavior::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
+                  std::map<std::string, History> &h) const {
     if (GetTransitionMatrices().size() != 1) {
         std::string error_msg =
             "Behavior error: Expected 1 transition matrix, got " +

--- a/src/internals/background.hpp
+++ b/src/internals/background.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -25,7 +25,7 @@ public:
     // Run the execute function and return the final state. Do not edit the
     // parameter state, but do edit the history provided. Nothing in the
     // Transition object should change.
-    Eigen::VectorXd Execute(const Eigen::VectorXd &s,
+    Eigen::VectorXd Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
                             std::map<std::string, History> &h) const override;
 
     // Clone

--- a/src/internals/behavior.hpp
+++ b/src/internals/behavior.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -25,7 +25,7 @@ public:
     // Run the execute function and return the final state. Do not edit the
     // parameter state, but do edit the history provided. Nothing in the
     // Transition object should change.
-    Eigen::VectorXd Execute(const Eigen::VectorXd &s,
+    Eigen::VectorXd Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
                             std::map<std::string, History> &h) const override;
 
     // Clone

--- a/src/internals/intervention.hpp
+++ b/src/internals/intervention.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -25,7 +25,7 @@ public:
     // Run the execute function and return the final state. Do not edit the
     // parameter state, but do edit the history provided. Nothing in the
     // Transition object should change.
-    Eigen::VectorXd Execute(const Eigen::VectorXd &s,
+    Eigen::VectorXd Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
                             std::map<std::string, History> &h) const override;
 
     // Clone

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-05-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -78,7 +78,9 @@ public:
     }
 
     // anticipate making a copy of the vector
-    void SetState(const Eigen::VectorXd &s) override { _state = s; }
+    void SetState(const Eigen::Ref<const Eigen::VectorXd> &s) override {
+        _state = s;
+    }
     // return const & to limit to observation of the state
     Eigen::VectorXd GetState() const override { return _state; }
     // return the transitions

--- a/src/internals/migration.hpp
+++ b/src/internals/migration.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -25,7 +25,7 @@ public:
     // Run the execute function and return the final state. Do not edit the
     // parameter state, but do edit the history provided. Nothing in the
     // Transition object should change.
-    Eigen::VectorXd Execute(const Eigen::VectorXd &s,
+    Eigen::VectorXd Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
                             std::map<std::string, History> &h) const override;
 
     // Clone

--- a/src/internals/overdose.hpp
+++ b/src/internals/overdose.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -25,7 +25,7 @@ public:
     // Run the execute function and return the final state. Do not edit the
     // parameter state, but do edit the history provided. Nothing in the
     // Transition object should change.
-    Eigen::VectorXd Execute(const Eigen::VectorXd &s,
+    Eigen::VectorXd Execute(const Eigen::Ref<const Eigen::VectorXd> &s,
                             std::map<std::string, History> &h) const override;
 
     // Clone

--- a/src/internals/transition_base.hpp
+++ b/src/internals/transition_base.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -24,7 +24,8 @@ public:
     // Add a Transition Matrix to the set. We have no need to edit it once it's
     // been added, just use it. Thus, we don't need full ownership (reference)
     // and can accept the const type.
-    void AddTransitionMatrix(const Eigen::MatrixXd &m) override {
+    void
+    AddTransitionMatrix(const Eigen::Ref<const Eigen::MatrixXd> &m) override {
         _transition_matrices.push_back(m);
     }
     // Get the name of the Transition. No need to edit the object and do not

--- a/src/intervention.cpp
+++ b/src/intervention.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-05                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -19,8 +19,9 @@
 #include <spdlog/spdlog.h>
 
 namespace respond {
-Eigen::VectorXd Intervention::Execute(const Eigen::VectorXd &state,
-                                      std::map<std::string, History> &h) const {
+Eigen::VectorXd
+Intervention::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
+                      std::map<std::string, History> &h) const {
     if (GetTransitionMatrices().size() != 1) {
         std::string error_msg =
             "Intervention error: Expected 1 transition matrix, got " +

--- a/src/migration.cpp
+++ b/src/migration.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -19,8 +19,9 @@
 #include <spdlog/spdlog.h>
 
 namespace respond {
-Eigen::VectorXd Migration::Execute(const Eigen::VectorXd &state,
-                                   std::map<std::string, History> &h) const {
+Eigen::VectorXd
+Migration::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
+                   std::map<std::string, History> &h) const {
     if (GetTransitionMatrices().size() != 1) {
         std::string error_msg =
             "Migration error: Expected 1 transition matrix, got " +

--- a/src/overdose.cpp
+++ b/src/overdose.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -19,8 +19,9 @@
 #include <spdlog/spdlog.h>
 
 namespace respond {
-Eigen::VectorXd Overdose::Execute(const Eigen::VectorXd &state,
-                                  std::map<std::string, History> &h) const {
+Eigen::VectorXd
+Overdose::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
+                  std::map<std::string, History> &h) const {
     if (GetTransitionMatrices().size() != 2) {
         std::string error_msg =
             "Overdose error: Expected 2 transition matrices, got " +

--- a/tests/mocks/model_mock.hpp
+++ b/tests/mocks/model_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-12                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -30,7 +30,8 @@ namespace respond {
 namespace testing {
 class MockModel : public virtual Model {
 public:
-    MOCK_METHOD(void, SetState, (const Eigen::VectorXd &), (override));
+    MOCK_METHOD(void, SetState, (const Eigen::Ref<const Eigen::VectorXd> &),
+                (override));
     MOCK_METHOD(Eigen::VectorXd, GetState, (), (const, override));
     MOCK_METHOD(void, RunTransitions, (), (override));
     MOCK_METHOD(void, AddTransition, (const std::unique_ptr<Transition> &),

--- a/tests/mocks/transition_mock.hpp
+++ b/tests/mocks/transition_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-02-06                                                  //
+// Last Modified: 2026-06-25                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -28,10 +28,11 @@ namespace testing {
 class MockTransition : public virtual Transition {
 public:
     MOCK_METHOD(Eigen::VectorXd, Execute,
-                ((const Eigen::VectorXd &), (std::map<std::string, History> &)),
+                ((const Eigen::Ref<const Eigen::VectorXd> &),
+                 (std::map<std::string, History> &)),
                 (const, override));
-    MOCK_METHOD(void, AddTransitionMatrix, (const Eigen::MatrixXd &),
-                (override));
+    MOCK_METHOD(void, AddTransitionMatrix,
+                (const Eigen::Ref<const Eigen::MatrixXd> &), (override));
     MOCK_METHOD(std::string, GetTransitionName, (), (const, override));
     MOCK_METHOD(void, ClearTransitionMatrices, (), (override));
     MOCK_METHOD(std::string, GetLogName, (), (const, override));


### PR DESCRIPTION
## What does this PR do?

Changing all eigen reference parameters to eigen ref class parameters for generic numpy conversions. This was done to attempt to make `respondpy` pass by reference easier through Pybind11.

## What Wrike task is this associated with?

## Checklist before merging

- [x] If adding a core feature, I've added related tests.
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
