### PR TITLE
[Feature] History and UML Update

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -48,7 +48,7 @@ PROJECT_NAME           = RESPOND
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.4.0
+PROJECT_NUMBER         = 2.5.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -22,21 +22,14 @@ The [original RESPOND model](https://github.com/SyndemicsLab/RESPONDv1/tree/main
 
 RESPOND makes full use of the CMake build system. It is a common tool used throughout the C++ user-base and we utilize it for dependency management, linking, and testing. As C++ has poor package management, we intentionally decided to move our focus away from tools such as conan and vcpkg and stay with pure CMake. Not to say we would never publish with such package managers, but it is not a core focus of the refactor/engineering team.
 
-We natively support 5 different build workflows with the `CMakePresets.json` file. They are:
-
-1. `test-debug-gcc-linux-shared-workflow`
-2. `test-debug-gcc-linux-static-workflow`
-3. `package-release-gcc-linux-shared-workflow`
-4. `package-release-gcc-linux-static-workflow`
-5. `benchmark-linux-static-workflow`
-
-These workflows follow the pattern `{function}-{build}-gcc-linux-{library}-workflow` and have corresponding presets for build, test, and package. As we adopt more operating systems and compilers we will expand beyond gcc and linux.
+The project provides configure/build/test/package presets in `CMakePresets.json`.
+Common configure presets include `test-debug`, `test-release`, `test-debug-static`, `test-release-static`, `coverage`, `benchmark`, `package-shared`, `package-static`, and `docs`.
 
 Overall, we make use of 10 CMake variables. They are found in the [options.cmake file](cmake/options.cmake) and all are set accordingly in the `CMakePresets.json`.
 
 ## Dependencies
 
-We make abundant use of the CMake `FetchContent` feature released in CMake 3.11. We utilize features added in CMake 3.24 to check if the package is previously installed, so the minimum required version of CMake is **3.24**.
+We make abundant use of the CMake `FetchContent` feature released in CMake 3.11, plus newer preset and dependency features. The minimum required version of CMake is **3.27**.
 
 The required dependencies are:
 
@@ -54,7 +47,9 @@ If you would like to clone and build this locally, it is a relatively straightfo
 ```shell
 git clone https://github.com/SyndemicsLab/respond.git
 cd respond
-cmake --workflow --preset test-debug-gcc-linux-shared-workflow
+cmake --preset test-debug
+cmake --build --preset test-debug
+ctest --preset test-debug
 ```
 
 And then the model is build and installed. Our default location is a build directory in the repository, but the CMake Install Directory can be pointed to wherever the user desires.
@@ -167,7 +162,9 @@ Open `build/static/docs/doxygen/html/index.html` in a browser.
 After building with tests enabled:
 
 ```shell
-cmake --workflow --preset test-debug-gcc-linux-static-workflow
+cmake --preset test-debug-static
+cmake --build --preset test-debug-static
+ctest --preset test-debug-static
 ```
 
 Tests verify all core components (models, transitions, history tracking).

--- a/docs/src/api-guide.md
+++ b/docs/src/api-guide.md
@@ -139,7 +139,7 @@ auto state_at_t0 = hist.GetStateMap()[0];
 auto all_states = hist.GetStateAsVector();  // Contiguous vector, fills gaps
 
 // Query history properties
-std::string name = hist.GetHistoryName();
+std::string name = hist.GetName();
 std::string log_name = hist.GetLogName();
 
 // Clear history
@@ -153,7 +153,7 @@ hist.Clear();
   - If timestep already exists, currently overwrites
 - `GetStateMap() const`: Returns map of timestep → state vector
 - `GetStateAsVector() const`: Returns contiguous vector of states (fills gaps with zeros)
-- `GetHistoryName() const`: Returns history identifier
+- `GetName() const`: Returns history identifier
 - `GetLogName() const`: Returns logger name
 - `Clear()`: Removes all recorded states
 - `operator==`, `operator!=`: Comparison operators

--- a/docs/src/api-guide.md
+++ b/docs/src/api-guide.md
@@ -8,9 +8,9 @@ The RESPOND library provides a flexible framework for building opioid use disord
 
 - **Model**: Abstract base class representing a state transition system
 - **Simulation**: Aggregates and coordinates multiple models
+- **Timestep**: Owns and sequences transitions for one simulation step
 - **Transition**: Abstract base for specific transition types
 - **History**: Tracks state vectors over time
-- **TransitionFactory**: Creates concrete transition instances
 
 ## Core Concepts
 
@@ -20,7 +20,7 @@ Models operate on state vectors (Eigen::VectorXd) representing the population di
 
 ### Transitions
 
-Transitions apply transformations to state vectors using transition matrices. The RESPOND model supports several transition types:
+Transitions apply transformations to state vectors using transition matrices or vectors. The RESPOND model supports several transition types:
 
 - **Migration**: Population movement between states
 - **Behavior**: Behavioral state changes
@@ -30,7 +30,7 @@ Transitions apply transformations to state vectors using transition matrices. Th
 
 ### History Tracking
 
-History objects record state vectors at each timestep, enabling analysis of state trajectories over time. Histories support sparse timesteps—gaps are automatically filled with zero vectors.
+History objects record state vectors at timesteps, enabling analysis of state trajectories over time. Histories support sparse timesteps and can return contiguous vectors with zero-filled gaps.
 
 ## Model Class
 
@@ -38,22 +38,25 @@ The Model class is the abstract base for all models in RESPOND.
 
 ```cpp
 #include <respond/model.hpp>
+#include <respond/timestep.hpp>
+#include <respond/transition.hpp>
 
 // Create a model
-auto model = respond::Model::Create("model_name", "logger_name");
+auto model = respond::Model::Create("markov", "logger_name");
 
 // Set the initial state
 Eigen::VectorXd initial_state(50);
 initial_state.setZero();
 model->SetState(initial_state);
 
-// Add transitions
-auto transition = respond::Transition::Create("behavior", "logger_name");
+// Build one timestep with transitions
+respond::Timestep step("logger_name");
+auto &transition = step.CreateTransition("behavior");
 transition->AddMatrix(some_matrix);
-model->AddTransition(transition);
+model->AddTimestep(step);
 
 // Execute one simulation step
-model->RunTransitions();
+model->RunTimestep();
 
 // Retrieve current state
 Eigen::VectorXd current_state = model->GetState();
@@ -64,17 +67,17 @@ auto histories = model->GetHistories();
 
 ### Key Methods
 
-- `SetState(const Eigen::VectorXd &state)`: Sets the model's state vector (copied internally)
-- `GetState() const`: Returns a copy of the current state
-- `RunTransitions()`: Executes all registered transitions
-- `AddTransition(const std::unique_ptr<Transition> &t)`: Adds a transition (assumes ownership)
-- `GetTransitionNames() const`: Returns names of all transitions
-- `ClearTransitions()`: Removes all transitions
+- `SetState(const Eigen::Ref<const Eigen::VectorXd> &state)`: Sets the model's state vector
+- `GetState() const`: Returns a const Eigen ref to the current state
+- `AddTimestep(const Timestep &timestep)`: Adds a timestep (deep-copied)
+- `RunTimestep()`: Runs the current timestep and advances time
+- `RunTimestep(size_t idx)`: Runs a specific timestep index
+- `RunTimesteps()`: Runs all registered timesteps (bounded by final timestep when set)
+- `ClearTimesteps()`: Removes all timesteps
 - `GetHistories() const`: Returns map of history name to History objects
 - `CreateDefaultHistories()`: Initializes default history tracking
-- `SetHistories(const std::map<std::string, History> &h)`: Sets history records
+- `ClearHistories()`: Clears history records and resets history tracking
 - `GetName() const`: Returns model name
-- `GetLogName() const`: Returns associated logger name
 - `clone() const`: Creates a deep copy of the model
 
 ## Simulation Class
@@ -93,28 +96,31 @@ auto model2 = respond::Model::Create("model2", "my_logger");
 sim.AddModel(model1);
 sim.AddModel(model2);
 
-// Run one step (executes all model transitions)
-sim.Run();
+// Run 52 timesteps for all models
+sim.Run(52);
 
 // Retrieve results
-auto all_histories = sim.GetModelHistories();
+auto model_0_histories = sim.GetModelHistory(0);
 auto model_names = sim.GetModelNames();
 
-// Get detailed history mapping
-auto history_names = sim.GetModelHistoryNames();
-// Returns vector of (model_name, history_name) pairs
+// Get history names for one model
+auto history_names = sim.GetModelHistoryNames(0);
 ```
 
 ### Key Methods
 
-- `Run()`: Executes one simulation step for all models
+- `Run(int duration = -1)`: Runs all models for the configured duration
+- `SetDuration(int duration)`: Sets default duration used by `Run()` when no argument is provided
 - `AddModel(const std::unique_ptr<Model> &model)`: Adds a model (cloned internally)
 - `GetModels() const`: Returns const reference to model vector
+- `GetModel(size_t idx) const`: Returns one model by index
+- `GetModel(const std::string &name) const`: Returns one model by name
 - `GetModelNames() const`: Returns all model names
 - `ClearModels()`: Removes all models
-- `GetModelHistories() const`: Returns state histories for all models
-- `GetModelHistoryNames() const`: Returns (model_name, history_name) pairs
-- `GetLogName() const`: Returns logger name
+- `GetModelHistory(size_t idx) const`: Returns one model's history map
+- `GetModelHistory(const std::string &name) const`: Returns one model's history map
+- `GetModelHistoryNames(size_t idx) const`: Returns history names for one model
+- `GetModelHistoryNames(const std::string &name) const`: Returns history names for one model
 
 ## History Class
 
@@ -140,7 +146,7 @@ auto all_states = hist.GetStateAsVector();  // Contiguous vector, fills gaps
 
 // Query history properties
 std::string name = hist.GetName();
-std::string log_name = hist.GetLogName();
+respond::HistoryMode mode = hist.GetHistoryMode();
 
 // Clear history
 hist.Clear();
@@ -152,40 +158,43 @@ hist.Clear();
   - If timestep < 0, automatically assigns next available timestep
   - If timestep already exists, currently overwrites
 - `GetStateMap() const`: Returns map of timestep → state vector
+- `GetRecordedTimesteps() const`: Returns stored timesteps without densifying
+- `GetRecordedStates() const`: Returns stored states without densifying
 - `GetStateAsVector() const`: Returns contiguous vector of states (fills gaps with zeros)
 - `GetName() const`: Returns history identifier
-- `GetLogName() const`: Returns logger name
+- `GetLatestRecordedTimestep() const`: Returns latest recorded timestep
+- `GetPendingState() const`: Returns pending aggregate for accumulated histories
+- `HasPendingState() const`: Indicates pending aggregate state
 - `Clear()`: Removes all recorded states
 - `operator==`, `operator!=`: Comparison operators
 
 ## Transition Class
 
-The Transition class is abstract; use TransitionFactory to create concrete instances.
+The Transition class is abstract; use `Transition::Create(...)` to create concrete instances.
 
 ```cpp
 #include <respond/transition.hpp>
-#include <respond/transition_factory.hpp>
 
-// Create a transition using the factory
+// Create a transition
 auto transition = respond::Transition::Create(
-    "behavior",  // Type: migration, behavior, intervention, overdose, background_death
-    "my_logger"  // Logger name
+    "behavior",      // Type
+    "behavior_name", // Instance name
+    "my_logger"      // Logger name
 );
 
 // Add transformation matrices
 Eigen::MatrixXd trans_matrix = ...;
 transition->AddMatrix(trans_matrix);
 
-// Execute the transition (typically done via Model::RunTransitions)
+// Execute the transition (typically done by model timesteps)
 auto histories_map = ...; // From model
 Eigen::VectorXd result = transition->Execute(current_state, histories_map);
 
 // Get transition properties
-std::string name = transition->GetTransitionName();
-std::string log = transition->GetLogName();
+std::string name = transition->GetName();
 
 // Clear matrices
-transition->ClearTransitionMatrices();
+transition->ClearMatrices();
 ```
 
 ### Supported Transition Types
@@ -216,7 +225,7 @@ respond::CreateFileLogger("my_logger", "path/to/logfile.log");
 ```cpp
 #include <respond/simulation.hpp>
 #include <respond/model.hpp>
-#include <respond/transition_factory.hpp>
+#include <respond/timestep.hpp>
 #include <respond/logging.hpp>
 
 int main() {
@@ -227,35 +236,36 @@ int main() {
     respond::Simulation sim("app");
 
     // Create and configure a model
-    auto model = respond::Model::Create("population_model", "app");
+    auto model = respond::Model::Create("markov", "app");
     
     // Set initial state (e.g., 1000 individuals across 50 states)
     Eigen::VectorXd initial_state = Eigen::VectorXd::Zero(50);
     initial_state(0) = 1000;  // All in first state
     model->SetState(initial_state);
 
-    // Add transitions
-    auto behavior_transition = respond::Transition::Create(
-        "behavior", "app");
-    // Add matrices...
-    model->AddTransition(behavior_transition);
+    // Create a reusable timestep with transitions
+    respond::Timestep step("app");
 
-    auto migration_transition = respond::Transition::Create(
-        "migration", "app");
-    // Add matrices...
-    model->AddTransition(migration_transition);
+    auto &behavior_transition = step.CreateTransition("behavior");
+    // behavior_transition->AddMatrix(...);
+
+    auto &migration_transition = step.CreateTransition("migration");
+    // migration_transition->AddMatrix(...);
+
+    // Register timesteps on the model
+    for (int t = 0; t < 52; ++t) {
+        model->AddTimestep(step);
+    }
 
     // Add model to simulation
     sim.AddModel(model);
 
     // Run simulation for 52 timesteps
-    for (int t = 0; t < 52; ++t) {
-        sim.Run();
-    }
+    sim.Run(52);
 
     // Extract results
-    auto histories = sim.GetModelHistories();
-    auto history_names = sim.GetModelHistoryNames();
+    auto histories = sim.GetModelHistory(0);
+    auto history_names = sim.GetModelHistoryNames(0);
     
     // Process results...
     
@@ -269,17 +279,16 @@ RESPOND uses `std::unique_ptr` for ownership management:
 
 - Models and Transitions are typically managed by Simulation or parent objects
 - History objects are copyable and can be freely copied
-- All models are cloned when added to a Simulation (ownership transfer)
-- Clearing containers (ClearModels, ClearTransitions) deletes contained objects
+- All models are cloned when added to a Simulation
+- Clearing containers (for example `ClearModels`, `ClearTimesteps`) deletes contained objects
 
 ## Best Practices
 
-1. **Use TransitionFactory** to create transitions—it handles type dispatch
-2. **Let Simulation manage models** for automatic cloning and lifecycle management
-3. **Reuse History objects** for multiple runs to accumulate results
-4. **Use const references** where available (GetState returns a copy for safety)
-5. **Initialize loggers early** before creating models to enable error tracking
-6. **Validate matrix dimensions** before adding to transitions (not checked by API)
+1. **Use `Transition::Create`** to create transitions by type.
+2. **Build timesteps explicitly** and add them to models in execution order.
+3. **Set simulation duration intentionally** (`SetDuration` or `Run(duration)`) to match timestep plans.
+4. **Initialize loggers early** before creating models and transitions.
+5. **Validate matrix dimensions and ranges** before adding matrices.
 
 ## Common Patterns
 
@@ -289,13 +298,11 @@ RESPOND uses `std::unique_ptr` for ownership management:
 for (int run = 0; run < num_runs; ++run) {
     respond::Simulation sim("logger_" + std::to_string(run));
     
-    auto model = respond::Model::Create("model", "logger_" + std::to_string(run));
+    auto model = respond::Model::Create("markov", "logger_" + std::to_string(run));
     // Configure model...
     
     sim.AddModel(model);
-    for (int t = 0; t < duration; ++t) {
-        sim.Run();
-    }
+    sim.Run(duration);
     
     // Store results...
 }
@@ -308,8 +315,8 @@ for (int run = 0; run < num_runs; ++run) {
 Eigen::VectorXd initial_state = ...;
 model->SetState(initial_state);
 
-// To also clear history
-model->ClearTransitions();
+// To also clear history and timesteps
+model->ClearTimesteps();
 model->CreateDefaultHistories();
 ```
 
@@ -368,20 +375,18 @@ void RunSimulation(int id, const std::string& log_file) {
     
     // Create and run simulation
     respond::Simulation sim(logger_name);
-    auto model = respond::Model::Create("model", logger_name);
+    auto model = respond::Model::Create("markov", logger_name);
     
     // Configure model...
     Eigen::VectorXd initial_state = Eigen::VectorXd::Zero(50);
     initial_state(0) = 1000;
     model->SetState(initial_state);
     
-    // Add transitions...
+    // Add timesteps...
     sim.AddModel(model);
     
     // Run simulation
-    for (int t = 0; t < 52; ++t) {
-        sim.Run();
-    }
+    sim.Run(52);
     
     // Flush logs for this model
     respond::FlushAllLoggers();

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -13,32 +13,25 @@ RESPOND follows the **inversion of control** principle, abstracting the model to
 
 ## Component Architecture
 
-```
-┌─────────────────────────────────────────────────┐
-│         Simulation                               │
-│  (aggregates and coordinates Models)             │
-└──────────────────┬──────────────────────────────┘
-                   │
-        ┌──────────┴──────────┬──────────────┐
-        │                     │              │
-    ┌───▼────┐           ┌───▼────┐     ┌──▼────┐
-    │ Model  │           │ Model  │     │ Model │
-    │ (PopA) │           │ (PopB) │     │(PopC) │
-    └───┬────┘           └───┬────┘     └──┬────┘
-        │                     │             │
-        ├─ Transitions ────┐  │             │
-        │   - Migration    │  │             │
-        │   - Behavior     │  │             │
-        │   - Intervention │  │             │
-        │   - Overdose     │  │             │
-        │   - Background   │  │             │
-        └──────────────────┘  │             │
-        │                     │             │
-        └─ Histories ────┐    │             │
-            - State      │    │             │
-            - Outcomes   │    │             │
-            - Costs      │    │             │
-            └────────────┘    └─────────────┘
+```mermaid
+flowchart TB
+  S[Simulation\naggregates and coordinates models]
+
+  M1[Model PopA]
+  M2[Model PopB]
+  M3[Model PopC]
+
+  S --> M1
+  S --> M2
+  S --> M3
+
+  TS1[Timesteps\n- Step 0\n- Step 1\n- ...]
+  TR1[Transitions per step\n- Migration\n- Behavior\n- Intervention\n- Overdose\n- BackgroundDeath]
+  H1[Histories\n- State\n- Outcomes\n- Costs]
+
+  M1 --> TS1
+  TS1 --> TR1
+  M1 --> H1
 ```
 
 ## Core Classes
@@ -48,13 +41,13 @@ RESPOND follows the **inversion of control** principle, abstracting the model to
 - **Role**: Represents a state transition system
 - **Responsibilities**:
   - Manages state vector
-  - Owns and executes transitions
+  - Owns and executes timesteps
   - Tracks history
   - Provides cloning capability
 - **Key Design Decisions**:
   - Non-copyable by assignment (enforces `clone()` usage for clarity)
-  - Owns transitions (unique_ptr for memory safety)
-  - Read-only GetState() (returns copy to prevent external state modification)
+  - Owns timesteps by value (timestep owns transition instances)
+  - Read-only GetState() (returns a const Eigen ref for observation)
 
 ### Simulation
 
@@ -106,7 +99,7 @@ RESPOND follows the **inversion of control** principle, abstracting the model to
   - Encapsulates type dispatch logic
   - Provides single point of extensibility for new transitions
 - **Key Design Decisions**:
-  - Static factory method (no factory state needed)
+  - Static creation on `Transition::Create(...)` (no factory state needed)
   - String-based type identification (simple, extensible)
   - Case-insensitive type matching (user-friendly)
 
@@ -125,14 +118,15 @@ auto transition = Transition::Create("behavior", "logger");
 - Centralizes type dispatch logic
 - Easy to add new transition types
 
-### Template Method Pattern (Model → Transitions)
+### Template Method Pattern (Model → Timesteps → Transitions)
 
-Model delegates to transitions in RunTransitions():
+Model delegates execution through timesteps, and each timestep applies its transitions in sequence:
 
 ```cpp
-void Model::RunTransitions() {
-    for (const auto& transition : _transitions) {
-        _state = transition->Execute(_state, _histories);
+void Model::RunTimestep(size_t idx) {
+  auto transitions = _timestep_vector[idx].GetTransitions();
+  for (const auto& transition : transitions) {
+    _state = transition->Execute(_state, _histories);
     }
 }
 ```
@@ -178,7 +172,7 @@ RESPOND uses modern C++ memory management practices:
 ### Unique Ownership (unique_ptr)
 
 Used for objects with clear ownership:
-- Model owns its Transitions
+- Timestep owns its Transitions
 - Simulation owns its Models (via cloning)
 
 ### Shared Ownership (None by default)
@@ -203,7 +197,7 @@ RESPOND minimizes shared state. History objects are the exception—they're:
 
 ### Adding a New Transition Type
 
-1. Create a new header in `include/respond/internals/`
+1. Create a new header in `src/internals/`
 2. Implement concrete Transition subclass
 3. Add factory entry in `Transition::Create()`
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,7 +16,7 @@ The [original RESPOND model](https://github.com/SyndemicsLab/RESPONDv1/tree/main
 
 RESPOND makes full use of the CMake build system. It is a common tool used throughout the C++ user-base and we utilize it for dependency management, linking, and testing. As C++ has poor package management, we intentionally decided to move our focus away from tools such as conan and vcpkg and stay with pure CMake. Not to say we would never publish with such package managers, but it is not a core focus of the refactor/engineering team.
 
-Currently our CMake supports 10 different workflows. They are named using the following convention: `<exetype>-<versiontype>-<os>-<shared/static>-workflow`. Please consult the CMakePresets.json or run `cmake --workflow --list-presets` to see the entire list.
+Current CMake support is provided through configure/build/test/package presets in `CMakePresets.json` (for example `test-debug`, `test-release`, `test-debug-static`, `benchmark`, `package-shared`, `package-static`, and `docs`). Please consult `CMakePresets.json` or run `cmake --list-presets` to see the available options.
 
 ### Fetch Content
 
@@ -36,7 +36,7 @@ FetchContent_MakeAvailable(respond)
 
 ## Dependencies
 
-As mentioned above, we utilize the  CMake `FetchContent` feature released in CMake 3.11. Additionally, we utilize features added in CMake 3.24 to check if the package is previously installed, so the minimum required version of CMake is **3.24**.
+As mentioned above, we utilize the CMake `FetchContent` feature released in CMake 3.11. We also rely on newer preset and dependency features, so the minimum required version of CMake is **3.27**.
 
 The required dependencies are:
 

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -1,29 +1,24 @@
 # Limitations
 
-Currently the RESPOND model and overall Simdemics Modeling Library are in heavy development. This means they have A LOT of current limitations. Any requests should be directed to the issues page on the github repository and the maintainers will work on them as permits. That being said, some readily identified limitations that have been identified are:
+RESPOND is under active development. The following limitations reflect the current C++ library behavior.
 
 ## Library
 
-The code base started as a specific model and many of the library limitations are due to old code and notations being maintained. That being said, this is an area of continuous improvement so watch for updates:
+The core API is stable enough for integration, but there are important constraints:
 
-- `DataLoader` currently only supports RESPOND
-- The RESPOND model currently requires `DataLoader`
-- `DataLoader` makes use of the csv file structure
-- Specific file names are required for `DataLoader`
-- Column names must be exact
-- Behavior and intervention names must be underscored instead of spaces or dashes
-- The model cannot be run on a GPU
-- Windows hangs during unit tests
-- There is no generalized linux build
-- Installation requires adding the respond cmake folder path to the `CMAKE_PREFIX_PATH`
+- `Model::Create(...)` currently returns the Markov implementation; additional model families are not yet exposed through the public factory.
+- Execution is timestep-driven; users must construct timesteps and transitions explicitly.
+- Transition creation is string-based (`Transition::Create(...)`), so invalid type names fail at runtime.
+- The library is not internally synchronized for shared mutable use across threads.
+- GPU execution is not supported.
+- Legacy standalone executable workflows are maintained separately from the modern library API.
 
 ## Data
 
-Currently, there are a lot of limitations in the required data structure.
+RESPOND C++ focuses on simulation primitives (state vectors, transitions, histories) rather than built-in dataset ingestion.
 
-- `sim.conf` timestep lists must contain the duration as the final value in the list
-- All oud columns should be renamed to behaviors
-- The Demographic structure still exists in the data without any impact to the model
+- Users are responsible for preparing and validating transition inputs (matrices/vectors) before simulation.
+- Schema conventions from legacy tooling (for example `sim.conf` and CSV pipelines) are not part of the required core C++ API.
 
 Previous: [Under the Hood](math.md)
 

--- a/docs/src/run.md
+++ b/docs/src/run.md
@@ -20,13 +20,15 @@ For C++ developers, RESPOND can be integrated directly into projects. See the [C
 ```cpp
 #include <respond/simulation.hpp>
 #include <respond/model.hpp>
+#include <respond/timestep.hpp>
+#include <respond/transition.hpp>
 
 int main() {
     // Create a simulation
     respond::Simulation sim("my_logger");
     
     // Create and configure a model
-    auto model = respond::Model::Create("population_model", "my_logger");
+    auto model = respond::Model::Create("markov", "my_logger");
     
     // Set initial state
     Eigen::VectorXd initial_state(50);
@@ -34,21 +36,24 @@ int main() {
     initial_state(0) = 1000;  // 1000 individuals in state 0
     model->SetState(initial_state);
     
-    // Add transitions
-    auto transition = respond::Transition::Create(
-        "behavior", "my_logger");
-    model->AddTransition(transition);
+    // Build one timestep and attach transitions
+    respond::Timestep step("my_logger");
+    auto &transition = step.CreateTransition("behavior");
+    // transition->AddMatrix(...);
+
+    // Add timesteps to the model
+    for (int t = 0; t < 52; ++t) {
+        model->AddTimestep(step);
+    }
     
     // Add model to simulation
     sim.AddModel(model);
     
     // Run simulation for 52 timesteps
-    for (int t = 0; t < 52; ++t) {
-        sim.Run();
-    }
+    sim.Run(52);
     
     // Extract results
-    auto histories = sim.GetModelHistories();
+    auto histories = sim.GetModelHistory(0);
     
     return 0;
 }

--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -13,10 +13,19 @@ classDiagram
     direction LR
 
     class Simulation {
-        +CreateNewModel(type) shared_ptr~Model~
-        +AddNewModel(shared_ptr~Model~) bool
-        +Run()
-        +GetModel(size_t model_idx) const Model &
+        +Simulation()
+        +Simulation(const string &)
+        +Simulation(const string &, const string &)
+        +Simulation(const Simulation &)
+        +operator=(const Simulation &) Simulation&
+        +Simulation(Simulation &&other)
+        +operator=(Simulation &&) Simulation&
+        +CreateNewModel(const string &) const string
+        +ClearModels()
+        +AddModel(const unique_ptr~Model~)
+        +Run(int=-1)
+        +GetModels() const vector~unique_ptr~Model~~ &
+        +GetModel(size_t model_idx) const unique_ptr~Model~ &
         +GetModelNames() vector~string~
         +GetModelHistory(size_t model_idx) map~string, History~
         +operator<<(ostream &os, const Simulation &obj) ostream &

--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -38,18 +38,27 @@ classDiagram
 
     class Model {
         <<abstract>>
-        +SetState(state) *
-        +GetState() VectorXd *
+        +Create(const string &, const string &, const string &) unique_ptr~Model~
+        +clone() unique_ptr~Model~ *
         +AddTimestep(shared_ptr~timestep~) *
-        +GetTimesteps() *
+        +RunTimestep() *
+        +RunTimestep(size_t) *
         +RunTimesteps() *
         +ClearTimesteps() *
-        +GetHistories() map~string, History~ *
         +ClearHistories() *
         +CreateDefaultHistories() *
-        +SetFinalTimestep(final_timestep) *
-        +clone() unique_ptr~Model~ *
-        +Create(name, log_name) unique_ptr~Model~
+        +GetTiemstepAtIndex(size_t) Timestep *
+        +GetState() Ref~const VectorXd~ *
+        +GetName() string *
+        +GetHistories() map~string, History~ *
+        +GetTimestep() int *
+        +GetHistoryCaptureInterval() int *
+        +GetFinalTimestep() int *
+        +GetInitialHistoryRecorded() bool *
+        +SetState(const Ref~const VectorXd~ &) *
+        +SetHistoryCaptureInterval(int) *
+        +SetFinalTimestep(int) *
+        +SetInitialHistoryRecorded(bool) *
         +operator<<(ostream &os, const Model &obj) ostream &
     }
 

--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -40,14 +40,14 @@ classDiagram
         <<abstract>>
         +Create(const string &, const string &, const string &) unique_ptr~Model~
         +clone() unique_ptr~Model~ *
-        +AddTimestep(shared_ptr~timestep~) *
+        +AddTimestep(const Timestep &) *
         +RunTimestep() *
         +RunTimestep(size_t) *
         +RunTimesteps() *
         +ClearTimesteps() *
         +ClearHistories() *
         +CreateDefaultHistories() *
-        +GetTiemstepAtIndex(size_t) Timestep *
+        +GetTimestepAtIndex(size_t) Timestep *
         +GetState() Ref~const VectorXd~ *
         +GetName() string *
         +GetHistories() map~string, History~ *
@@ -59,70 +59,98 @@ classDiagram
         +SetHistoryCaptureInterval(int) *
         +SetFinalTimestep(int) *
         +SetInitialHistoryRecorded(bool) *
+        +Serialize(ostream &) *
         +operator<<(ostream &os, const Model &obj) ostream &
     }
 
     class Timestep {
         +Timestep()
-        +Timestep(const string &log_name)
-        +Timestep(const string &log_name, const string &log_filepath)
-        +Timestep(const Timestep &other)
-        +operator=(const Timestep &other) Timestep &
-        +Timestep(const Timestep &&other)
-        +operator=(const Timestep &&other) Timestep &
-        +CreateTransition(type) const Transition &
-        +AddMatrixToTransition(size_t index, MatrixXd mat)
-        +GetTransition(size_t idx) const Transition &
-        +GetTransition(string name) const Transition &
-        +GetTransitions() const vector~const Transition &~
-        +GetTransitionNames() vector~const string~
+        +Timestep(const string &)
+        +Timestep(const string &, const string &)
+        +Timestep(const Timestep &)
+        +operator=(const Timestep &) Timestep &
+        +Timestep(const Timestep &&)
+        +operator=(const Timestep &&) Timestep &
+        +CreateTransition(const string &) const unique_ptr~Transition~ &
+        +RemoveTransition(size_t) unique_ptr~Transition~
+        +AddMatrixToTransition(const size_t &, const Ref~const MatrixXd~ &)
+        +AddMatrixToTransition(const string &, const Ref~const MatrixXd~ &)
+        +GetTransition(const size_t &) const unique_ptr~Transition~ &
+        +GetTransition(const string &) const unique_ptr~Transition~ &
+        +GetTransitions() vector~unique_ptr~Transition~~
+        +GetTransitionNames() vector~string~
         +operator<<(ostream &os, const Timestep &obj) ostream &
+        +operator==(const Timestep &, const Timestep &) bool
+        +operator!=(const Timestep &, const Timestep &) bool
     }
 
     class Transition {
         <<abstract>>
-        +Execute(state, histories) VectorXd *
-        +AddMatrix(const Eigen::Ref~const MatrixXd~ &matrix, size_t idx) *
-        +GetMatrix(size_t idx) Eigen::Ref~MatrixXd~ *
+        +Execute(const Ref Vector &, map~string, History~ &) VectorXd *
+        +AddMatrix(Eigen::Ref~const MatrixXd~) *
+        +GetMatrices() vector~MatrixXd~ *
         +GetName() string *
         +ClearMatrices() *
         +clone() unique_ptr~Transition~ *
-        +Create(type, log_name) unique_ptr~Transition~
-        +operator<<(ostream &os, const Transition &obj) ostream &
+        +Create(const string &, const string &, const string &, const string &) unique_ptr~Transition~
+        +Serialize(ostream &) *
+        +operator<<(ostream &, const Transition &) ostream &
     }
 
     class History {
-        +AddState(state, timestep)
-        +RecordSnapshot(state, timestep)
-        +AccumulateState(state)
-        +FlushPendingState(timestep, state_size)
+        +History()
+        +History(const string &)
+        +History(const string &, const HistoryMode &)
+        +History(const string &, const HistoryMode &, const string &)
+        +History(const string &, const string &)
+        +History(const string &, const string &, const string &)
+        +History(const string &, const HistoryMode &, const string &, const string &)
+        +History(const History &)
+        +operator=(const History &) History &
+        +History(History &&)
+        +operator=(History &&) History &
+        +AddState(const Ref~const VectorXd~ &, int)
+        +AccumulateState(const Ref~const VectorXd~ &)
+        +FlushPendingState(int, Index)
+        +Clear()
+        +HasPendingState() bool
         +GetStateMap() map~int, VectorXd~
+        +GetRecordedTimesteps() const vector~int~ &
+        +GetRecordedStates() const vector~VectorXd~ &
+        +GetHistoryMode() HistoryMode
+        +GetPendingState() VectorXd
+        +GetLatestRecordedTimestep() int
+        +GetName() string
         +GetStateAsVector() vector~VectorXd~
+        +operator==(const History &) bool
+        +operator!=(const History &) bool
         +operator<<(ostream &os, const History &obj) ostream &
+        -GetNextTimestep() int
+        -GetZeroVector(const int &) VectorXd
     }
 
     class HistoryMode {
         <<enumeration>>
-        Snapshot
-        Accumulated
+        kSnapshot
+        kAccumulated
     }
 
     class LoggingAPI {
         <<utility>>
-        +CreateFileLogger(name, filepath)
-        +CreateSharedFileSink(filepath)
-        +CreateSharedLogger(name)
-        +SetLogPattern(pattern)
-        +GetLogPattern()
-        +SetFlushInterval(seconds)
+        +CreateFileLogger(const string &, const string &)
+        +CreateSharedFileSink(const string &)
+        +CreateSharedLogger(const string &)
+        +SetLogPattern(LogPattern)
+        +GetLogPattern() LogPattern
+        +SetFlushInterval(int)
         +FlushAllLoggers()
-        +LogInfo(name, message)
-        +LogWarning(name, message)
-        +LogError(name, message)
-        +LogDebug(name, message)
-        +CheckLoggerExists(name)
-        +GetLoggerInfo(name)
-        +SetLoggerLevel(name, level)
+        +LogInfo(const string &, const string &)
+        +LogWarning(const string &, const string &)
+        +LogError(const string &, const string &)
+        +LogDebug(const string &, const string &)
+        +CheckLoggerExists(const string &)
+        +GetLoggerInfo(const string &)
+        +SetLoggerLevel(const string &, int)
     }
 
     class LogType {
@@ -183,13 +211,13 @@ classDiagram
 
     class Simulation {
         -string _log_name
-        -vector~shared_ptr~Model~~ _models
-        -size_t _duration
-        -vector~size_t~ _parameter_change_times
+        -vector~unique_ptr~Model~~ _models
+        -int _duration
+        -vector~int~ _parameter_change_times
         -bool _stratify_entering_cohort
         -bool _build_summary_stats
         -bool _save_state_history
-        -vector~size_t~ _timesteps_to_report
+        -vector~int~ _timesteps_to_report
         -bool _pivot_long
         +Simulation()
         +Simulation(const string log_name)
@@ -205,7 +233,7 @@ classDiagram
     }
 
     class Markov {
-        -vector~shared_ptr~Transition~~ _transition_vector
+        -vector~Timestep~ _timestep_vector
         -VectorXd _state
         -string _name
         -string _log_name
@@ -227,10 +255,12 @@ classDiagram
         +operator=(Markov &&other) Markov &
         +SetState(state) override
         +GetState() VectorXd override
-        +AddTimestep(shared_ptr~timestep~) override
-        +GetTimesteps() override
+        +AddTimestep(const Timestep &) override
+        +GetTimestepAtIndex(size_t) Timestep override
         +ClearTimesteps() override
-        +RunTransitions() override
+        +RunTimestep() override
+        +RunTimestep(size_t) override
+        +RunTimesteps() override
         +GetHistories() map~string, History~ override
         +ClearHistories() override
         +CreateDefaultHistories() override
@@ -247,11 +277,11 @@ classDiagram
         -string _name
         -string _log_name
         -vector~MatrixXd~ _transition_matrices
-        -GetMatrices() const vector<MatrixXd> &
-        +AddMatrix(const Eigen::Ref~const MatrixXd~ &matrix, size_t idx) override
+        +GetMatrices() const vector~MatrixXd~
+        +AddMatrix(const Eigen::Ref~const MatrixXd~ &) override
         +GetName() string override
         +ClearMatrices() override
-        +GetLogName() string override
+        +Serialize(ostream &) override
     }
 
     class Migration {
@@ -305,7 +335,8 @@ classDiagram
     TransitionBase <|-- Overdose : implements
     TransitionBase <|-- BackgroundDeath : implements
 
-    Markov *-- "0..*" Transition : owns
+    Markov *-- "0..*" Timestep : owns
+    Timestep *-- "0..*" Transition : owns
     Markov *-- "0..*" History : owns
     Migration <.. History : uses
     Behavior <.. History : uses

--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -26,8 +26,13 @@ classDiagram
         +Run(int=-1)
         +GetModels() const vector~unique_ptr~Model~~ &
         +GetModel(size_t model_idx) const unique_ptr~Model~ &
+        +GetModel(const string &) const unique_ptr~Model~ &
         +GetModelNames() vector~string~
-        +GetModelHistory(size_t model_idx) map~string, History~
+        +GetModelHistory(size_t model_idx) const map~string, History~ &
+        +GetModelHistory(const string &) const map~string, History~ &
+        +GetModelHistoryNames(size_t idx) vector~string~
+        +GetModelHistoryNames(const string &) vector~string~
+        +SetDuration(int)
         +operator<<(ostream &os, const Simulation &obj) ostream &
     }
 

--- a/extras/benchmark/README.md
+++ b/extras/benchmark/README.md
@@ -14,7 +14,7 @@ This benchmark target is designed for reproducible performance measurement of co
 
 The benchmark constructs one RESPOND model and measures repeated execution of:
 
-- `Model::RunTransitions()` for a fixed number of timesteps
+- `Simulation::Run(steps)` / `Model::RunTimesteps()` for a fixed number of timesteps
 - Transition mix: behavior, intervention, overdose, background death
 - Deterministic transition matrices/vectors and deterministic initial state
 

--- a/extras/benchmark/README.md
+++ b/extras/benchmark/README.md
@@ -25,14 +25,14 @@ Warm-up runs are excluded from reported timings.
 Enable benchmark builds in CMake:
 
 ```bash
-cmake -S . -B build/bench -DRESPOND_BUILD_BENCH=ON
-cmake --build build/bench --target respond_benchmark
+cmake --preset benchmark
+cmake --build --preset benchmark
 ```
 
 ## Run
 
 ```bash
-./build/bench/bin/respond_benchmark \
+./build/shared/bin/respond_benchmark \
   --state-size 64 \
   --steps 52 \
   --history-capture-interval 1 \

--- a/include/respond/cost_effectiveness.hpp
+++ b/include/respond/cost_effectiveness.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-06-25                                                  //
+// Last Modified: 2026-07-09                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -12,8 +12,6 @@
 
 #ifndef RESPOND_COSTEFFECTIVENESS_HPP_
 #define RESPOND_COSTEFFECTIVENESS_HPP_
-
-#include <iostream>
 
 #include <Eigen/Dense>
 

--- a/include/respond/history.hpp
+++ b/include/respond/history.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -50,26 +50,58 @@ inline HistoryMode GetDefaultHistoryMode(const std::string &name) {
 /// are filled with zero vectors).
 class History {
 public:
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // Rule of Five: Copy and Move Semantics
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @brief Default constructor initializing a history with the default name
+    /// "state" and default mode based on that name.
     History() : History("state") {}
 
+    /// @brief  Constructs a history with a specified name, using the default
+    /// mode based on that name.
+    /// @param name The identifier name for this history instance.
     History(const std::string &name)
         : History(name, GetDefaultHistoryMode(name)) {}
 
+    /// @brief Constructs a history with a specified name and mode.
+    /// @param name The identifier name for this history instance.
+    /// @param mode The history recording mode (snapshot or accumulated).
     History(const std::string &name, const HistoryMode &mode)
         : History(name, mode, RESPOND_DEFAULT_LOG, RESPOND_DEFAULT_LOG_FILE) {}
 
+    /// @brief Constructs a history with a specified name, mode, and logger.
+    /// @param name The identifier name for this history instance.
+    /// @param mode The history recording mode (snapshot or accumulated).
+    /// @param log_name The name of the logger to use for history output.
     History(const std::string &name, const HistoryMode &mode,
             const std::string &log_name)
         : History(name, mode, log_name, RESPOND_DEFAULT_LOG_FILE) {}
 
+    /// @brief Constructs a history with a specified name and logger.
+    /// @param name The identifier name for this history instance.
+    /// @param log_name The name of the logger to use for history output.
     History(const std::string &name, const std::string &log_name)
         : History(name, GetDefaultHistoryMode(name), log_name,
                   RESPOND_DEFAULT_LOG_FILE) {}
 
+    /// @brief Constructs a history with a specified name, logger, and log
+    /// file path.
+    /// @param name The identifier name for this history instance.
+    /// @param log_name The name of the logger to use for history output.
+    /// @param log_filepath The file path for the logger output.
     History(const std::string &name, const std::string &log_name,
             const std::string &log_filepath)
         : History(name, GetDefaultHistoryMode(name), log_name, log_filepath) {}
 
+    /// @brief Constructs a history with a specified name, mode, logger, and
+    /// log file path.
+    /// @param name The identifier name for this history instance.
+    /// @param mode The history recording mode (snapshot or accumulated).
+    /// @param log_name The name of the logger to use for history output.
+    /// @param log_filepath The file path for the logger output.
     History(const std::string &name, const HistoryMode &mode,
             const std::string &log_name, const std::string &log_filepath)
         : _name(name), _mode(mode), _log_name(log_name) {
@@ -78,14 +110,15 @@ public:
 
     /// @brief Destructor (default).
     ~History() = default;
+
     /// @brief Copy constructor implementing the Rule of Five.
     /// Creates an independent copy of the history state and metadata.
     History(const History &other) {
         _timesteps = other.GetRecordedTimesteps();
         _states = other.GetRecordedStates();
-        _name = other.GetHistoryName();
-        _log_name = other.GetLogName();
-        _mode = other.GetHistoryMode();
+        _name = other._name;
+        _log_name = other._log_name;
+        _mode = other._mode;
         _pending_state = other.GetPendingState();
     }
 
@@ -96,9 +129,9 @@ public:
         if (this != &other) {
             _timesteps = other.GetRecordedTimesteps();
             _states = other.GetRecordedStates();
-            _name = other.GetHistoryName();
-            _log_name = other.GetLogName();
-            _mode = other.GetHistoryMode();
+            _name = other._name;
+            _log_name = other._log_name;
+            _mode = other._mode;
             _pending_state = other.GetPendingState();
         }
         return *this;
@@ -110,9 +143,9 @@ public:
     History(History &&other) noexcept {
         _timesteps = std::move(other._timesteps);
         _states = std::move(other._states);
-        _name = other.GetHistoryName();
-        _log_name = other.GetLogName();
-        _mode = other.GetHistoryMode();
+        _name = other._name;
+        _log_name = other._log_name;
+        _mode = other._mode;
         _pending_state = std::move(other._pending_state);
     }
 
@@ -123,106 +156,19 @@ public:
         if (this != &other) {
             _timesteps = std::move(other._timesteps);
             _states = std::move(other._states);
-            _name = other.GetHistoryName();
-            _log_name = other.GetLogName();
-            _mode = other.GetHistoryMode();
+            _name = other._name;
+            _log_name = other._log_name;
+            _mode = other._mode;
             _pending_state = std::move(other._pending_state);
         }
         return *this;
     }
 
-    /// @brief Equality comparison operator.
-    /// @param other The history to compare with.
-    /// @return True if all history properties and state are identical.
-    bool operator==(const History &other) const {
-        return GetHistoryName() == other.GetHistoryName() &&
-               GetLogName() == other.GetLogName() &&
-               GetHistoryMode() == other.GetHistoryMode() &&
-               GetStateMap() == other.GetStateMap() &&
-               GetPendingState().isApprox(other.GetPendingState());
-    }
-
-    /// @brief Inequality comparison operator.
-    /// @param other The history to compare with.
-    /// @return True if histories differ in any aspect.
-    bool operator!=(const History &other) const { return !(*this == other); }
-
-    /// @brief Retrieves the complete state map (timestep -> state vector).
-    /// @return Map of integer timesteps to Eigen vectors representing states.
-    std::map<int, Eigen::VectorXd> GetStateMap() const {
-        std::map<int, Eigen::VectorXd> state_map;
-        for (size_t index = 0; index < _timesteps.size(); ++index) {
-            state_map[_timesteps[index]] = _states[index];
-        }
-        return state_map;
-    }
-
-    /// @brief Retrieves the recorded timesteps without densifying gaps.
-    /// @return Const reference to the stored timestep indices.
-    const std::vector<int> &GetRecordedTimesteps() const { return _timesteps; }
-
-    /// @brief Retrieves the recorded state vectors without densifying gaps.
-    /// @return Const reference to the stored state vectors.
-    const std::vector<Eigen::VectorXd> &GetRecordedStates() const {
-        return _states;
-    }
-
-    /// @brief Retrieves the configured history recording mode.
-    /// @return Snapshot or accumulated history mode.
-    HistoryMode GetHistoryMode() const { return _mode; }
-
-    /// @brief Indicates whether an accumulated history has pending state.
-    /// @return True when a pending aggregate exists.
-    bool HasPendingState() const { return _pending_state.size() > 0; }
-
-    /// @brief Retrieves the pending accumulated state.
-    /// @return The pending aggregate vector, or an empty vector if none.
-    Eigen::VectorXd GetPendingState() const { return _pending_state; }
-
-    /// @brief Retrieves the latest recorded timestep.
-    /// @return Largest recorded timestep, or -1 if history is empty.
-    int GetLatestRecordedTimestep() const {
-        if (_timesteps.empty()) {
-            return -1;
-        }
-        return _timesteps.back();
-    }
-
-    /// @brief Retrieves the identifier name of this history.
-    /// @return The history's name string.
-    std::string GetHistoryName() const { return _name; }
-
-    /// @brief Retrieves the logger name for this history.
-    /// @return The associated logger's name.
-    std::string GetLogName() const { return _log_name; }
-
-    /// @brief Converts the sparse history map to a contiguous vector of states.
-    /// Gaps in timesteps are filled with zero vectors of appropriate dimension.
-    /// @return Vector of Eigen vectors from timestep 0 to the maximum recorded
-    /// timestep. Returns empty vector if no state has been recorded.
-    std::vector<Eigen::VectorXd> GetStateAsVector() const {
-        std::vector<Eigen::VectorXd> ret;
-        if (_states.empty()) {
-            // warn empty state vector - no states recorded
-            return {};
-        }
-        int default_size = _states.front().size();
-        int tstep = 0;
-        for (size_t index = 0; index < _timesteps.size(); ++index) {
-            const int recorded_timestep = _timesteps[index];
-            const auto &recorded_state = _states[index];
-            if (recorded_timestep > tstep) {
-                // Fill gap: raise error if timestep mapping is invalid
-            }
-            while (recorded_timestep > tstep) {
-                ret.push_back(GetZeroVector(default_size));
-                tstep++;
-            }
-            ret.push_back(recorded_state);
-            tstep++;
-        }
-        return ret;
-    }
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // History Methods: State Vector Management
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
     /// @brief Records a state vector at a specific or automatic timestep.
     /// @param state The state vector to record.
@@ -249,18 +195,13 @@ public:
         _states.push_back(state);
     }
 
-    /// @brief Records a snapshot value at a concrete timestep.
-    /// @param state The snapshot value to record.
-    /// @param timestep The simulation timestep for this snapshot.
-    void RecordSnapshot(const Eigen::Ref<const Eigen::VectorXd> &state,
-                        int timestep) {
-        AddState(state, timestep);
-    }
-
     /// @brief Adds a contribution to an accumulated history.
     /// @param state The per-step contribution to accumulate.
     void AccumulateState(const Eigen::Ref<const Eigen::VectorXd> &state) {
         if (_mode != HistoryMode::kAccumulated) {
+            LogWarning(_log_name, "AccumulateState called on non-accumulated "
+                                  "history, adding state instead: " +
+                                      _name);
             AddState(state);
             return;
         }
@@ -277,6 +218,10 @@ public:
     /// @param state_size Size of a zero vector to record if nothing is pending.
     void FlushPendingState(int timestep, Eigen::Index state_size) {
         if (_mode != HistoryMode::kAccumulated) {
+            LogInfo(_log_name,
+                    "FlushPendingState called on non-accumulated history, "
+                    "no pending state to flush: " +
+                        _name);
             return;
         }
 
@@ -284,6 +229,10 @@ public:
         if (_pending_state.size() > 0) {
             value = _pending_state;
         } else {
+            LogInfo(_log_name,
+                    "FlushPendingState called with no pending state, "
+                    "recording zero vector: " +
+                        _name);
             value = Eigen::VectorXd::Zero(state_size);
         }
 
@@ -296,6 +245,115 @@ public:
         _timesteps.clear();
         _states.clear();
         _pending_state.resize(0);
+    }
+
+    /// @brief Indicates whether an accumulated history has pending state.
+    /// @return True when a pending aggregate exists.
+    bool HasPendingState() const { return _pending_state.size() > 0; }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // Getters and Setters for History Vectors
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @brief Retrieves the complete state map (timestep -> state vector).
+    /// @return Map of integer timesteps to Eigen vectors representing states.
+    std::map<int, Eigen::VectorXd> GetStateMap() const {
+        std::map<int, Eigen::VectorXd> state_map;
+        for (size_t index = 0; index < _timesteps.size(); ++index) {
+            state_map[_timesteps[index]] = _states[index];
+        }
+        return state_map;
+    }
+
+    /// @brief Retrieves the recorded timesteps without densifying gaps.
+    /// @return Const reference to the stored timestep indices.
+    const std::vector<int> &GetRecordedTimesteps() const { return _timesteps; }
+
+    /// @brief Retrieves the recorded state vectors without densifying gaps.
+    /// @return Const reference to the stored state vectors.
+    const std::vector<Eigen::VectorXd> &GetRecordedStates() const {
+        return _states;
+    }
+
+    /// @brief Retrieves the configured history recording mode.
+    /// @return Snapshot or accumulated history mode.
+    HistoryMode GetHistoryMode() const { return _mode; }
+
+    /// @brief Retrieves the pending accumulated state.
+    /// @return The pending aggregate vector, or an empty vector if none.
+    Eigen::VectorXd GetPendingState() const { return _pending_state; }
+
+    /// @brief Retrieves the latest recorded timestep.
+    /// @return Largest recorded timestep, or -1 if history is empty.
+    int GetLatestRecordedTimestep() const {
+        if (_timesteps.empty()) {
+            LogWarning(_log_name,
+                       "GetLatestRecordedTimestep called on empty history: " +
+                           _name);
+            return -1;
+        }
+        return _timesteps.back();
+    }
+
+    /// @brief Retrieves the identifier name of this history.
+    /// @return The history's name string.
+    std::string GetName() const { return _name; }
+
+    /// @brief Converts the sparse history map to a contiguous vector of states.
+    /// Gaps in timesteps are filled with zero vectors of appropriate dimension.
+    /// @return Vector of Eigen vectors from timestep 0 to the maximum recorded
+    /// timestep. Returns empty vector if no state has been recorded.
+    std::vector<Eigen::VectorXd> GetStateAsVector() const {
+        std::vector<Eigen::VectorXd> ret;
+        if (_states.empty()) {
+            LogWarning(_log_name,
+                       "GetStateAsVector called on empty history: " + _name);
+            return {};
+        }
+        int default_size = _states.front().size();
+        int tstep = 0;
+        for (size_t index = 0; index < _timesteps.size(); ++index) {
+            const int recorded_timestep = _timesteps[index];
+            const auto &recorded_state = _states[index];
+            while (recorded_timestep > tstep) {
+                ret.push_back(GetZeroVector(default_size));
+                tstep++;
+            }
+            ret.push_back(recorded_state);
+            tstep++;
+        }
+        return ret;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    // Operator Comparisons and Stream Output
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @brief Equality comparison operator.
+    /// @param other The history to compare with.
+    /// @return True if all history properties and state are identical.
+    bool operator==(const History &other) const {
+        return _name == other._name && _log_name == other._log_name &&
+               _mode == other._mode && GetStateMap() == other.GetStateMap() &&
+               GetPendingState().isApprox(other.GetPendingState());
+    }
+
+    /// @brief Inequality comparison operator.
+    /// @param other The history to compare with.
+    /// @return True if histories differ in any aspect.
+    bool operator!=(const History &other) const { return !(*this == other); }
+
+    friend std::ostream &operator<<(std::ostream &os, const History &history) {
+        os << "History(name=" << history._name << ", timesteps=[";
+        for (const auto &t : history._timesteps) {
+            os << t << ",";
+        }
+        os << "], pending_state=" << history._pending_state.transpose() << ")";
+        return os;
     }
 
 private:

--- a/include/respond/history.hpp
+++ b/include/respond/history.hpp
@@ -4,13 +4,16 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-06-30                                                  //
+// Last Modified: 2026-07-09                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
 ////////////////////////////////////////////////////////////////////////////////
 #ifndef RESPOND_HISTORY_HPP_
 #define RESPOND_HISTORY_HPP_
+
+#include <respond/constants.hpp>
+#include <respond/logging.hpp>
 
 #include <algorithm>
 #include <map>
@@ -20,14 +23,25 @@
 #include <Eigen/Dense>
 
 namespace respond {
-enum class HistoryMode { Snapshot, Accumulated };
 
+/// @brief Defines the mode of history recording for state vectors in a
+/// simulation.
+enum class HistoryMode : int {
+    kSnapshot = 0,    // Snapshot of state at each timestep
+    kAccumulated = 1, // Accumulated contributions over timesteps
+    kCount = 2        // Enum Counter
+};
+
+/// @brief Determines the default history mode based on the history name.
+/// @param name The name of the history to evaluate.
+/// @return HistoryMode::kAccumulated for specific names, otherwise
+/// HistoryMode::kSnapshot.
 inline HistoryMode GetDefaultHistoryMode(const std::string &name) {
     if (name == "intervention_admission" || name == "total_overdose" ||
         name == "fatal_overdose" || name == "background_death") {
-        return HistoryMode::Accumulated;
+        return HistoryMode::kAccumulated;
     }
-    return HistoryMode::Snapshot;
+    return HistoryMode::kSnapshot;
 }
 
 /// @brief Tracks and manages state vector history over time.
@@ -38,21 +52,29 @@ class History {
 public:
     History() : History("state") {}
 
-    History(const std::string &name) : History(name, "console") {}
-    /// @brief Constructs a History tracker.
-    /// @param name The identifier for this history (default: "state").
-    /// @param log_name The logger name for error reporting (default:
-    /// "console").
-    History(const std::string &name, const std::string &log_name)
-        : History(name, log_name, GetDefaultHistoryMode(name)) {}
+    History(const std::string &name)
+        : History(name, GetDefaultHistoryMode(name)) {}
 
-    /// @brief Constructs a History tracker with an explicit recording mode.
-    /// @param name The identifier for this history.
-    /// @param log_name The logger name for error reporting.
-    /// @param mode Whether the history stores snapshots or accumulations.
+    History(const std::string &name, const HistoryMode &mode)
+        : History(name, mode, RESPOND_DEFAULT_LOG, RESPOND_DEFAULT_LOG_FILE) {}
+
+    History(const std::string &name, const HistoryMode &mode,
+            const std::string &log_name)
+        : History(name, mode, log_name, RESPOND_DEFAULT_LOG_FILE) {}
+
+    History(const std::string &name, const std::string &log_name)
+        : History(name, GetDefaultHistoryMode(name), log_name,
+                  RESPOND_DEFAULT_LOG_FILE) {}
+
     History(const std::string &name, const std::string &log_name,
-            HistoryMode mode)
-        : _log_name(log_name), _name(name), _mode(mode) {}
+            const std::string &log_filepath)
+        : History(name, GetDefaultHistoryMode(name), log_name, log_filepath) {}
+
+    History(const std::string &name, const HistoryMode &mode,
+            const std::string &log_name, const std::string &log_filepath)
+        : _name(name), _mode(mode), _log_name(log_name) {
+        CreateFileLogger(log_name, log_filepath);
+    }
 
     /// @brief Destructor (default).
     ~History() = default;
@@ -238,7 +260,7 @@ public:
     /// @brief Adds a contribution to an accumulated history.
     /// @param state The per-step contribution to accumulate.
     void AccumulateState(const Eigen::Ref<const Eigen::VectorXd> &state) {
-        if (_mode != HistoryMode::Accumulated) {
+        if (_mode != HistoryMode::kAccumulated) {
             AddState(state);
             return;
         }
@@ -254,7 +276,7 @@ public:
     /// @param timestep The simulation timestep to record.
     /// @param state_size Size of a zero vector to record if nothing is pending.
     void FlushPendingState(int timestep, Eigen::Index state_size) {
-        if (_mode != HistoryMode::Accumulated) {
+        if (_mode != HistoryMode::kAccumulated) {
             return;
         }
 

--- a/include/respond/model.hpp
+++ b/include/respond/model.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -159,11 +159,33 @@ public:
     /// otherwise.
     virtual void SetInitialHistoryRecorded(bool recorded) = 0;
 
+    /// @brief Function to serialize the model's state and metadata to an output
+    /// stream.
+    /// @details This function is intended to be overridden by subclasses to
+    /// provide custom serialization logic. It should write the model's state,
+    /// metadata, and any relevant information to the provided output stream.
+    /// @note The output format is implementation-defined and may vary between
+    /// subclasses. Users should refer to the specific subclass documentation
+    /// for details on the serialization format.
+    /// @param os The output stream to which the model's serialized data will be
+    /// written.
+    virtual void Serialize(std::ostream &os) const = 0;
+
 protected:
     /// @brief Protected default constructor for subclass initialization.
     /// Not intended for direct public use.
     Model() = default;
 };
+
+/// @brief Overloaded stream insertion operator for Model serialization.
+/// @param os The output stream to write to.
+/// @param model The Model instance to serialize.
+/// @return The output stream after writing the model's serialized data.
+inline std::ostream &operator<<(std::ostream &os, const Model &model) {
+    model.Serialize(os);
+    return os;
+}
+
 } // namespace respond
 
 #endif // RESPOND_MODEL_HPP_

--- a/include/respond/simulation.hpp
+++ b/include/respond/simulation.hpp
@@ -188,6 +188,19 @@ public:
         return _models;
     }
 
+    /// @brief Retrieves a specific model by index in the simulation.
+    /// @param idx The index of the model to retrieve.
+    /// @return A const reference to the Model unique_ptr at the specified
+    /// index. Throws an exception if the index is out of range.
+    const std::unique_ptr<Model> &GetModel(size_t idx) const {
+        if (idx >= _models.size()) {
+            LogError(_log_name,
+                     "Index out of range in GetModel: " + std::to_string(idx));
+            throw std::out_of_range("Error attempting to GetModel by index.");
+        }
+        return _models[idx];
+    }
+
     /// @brief Retrieves the names of all models in the simulation.
     /// @return Vector of model names in the order they were added.
     std::vector<std::string> GetModelNames() const {

--- a/include/respond/simulation.hpp
+++ b/include/respond/simulation.hpp
@@ -201,6 +201,17 @@ public:
         return _models[idx];
     }
 
+    const std::unique_ptr<Model> &
+    GetModel(const std::string &model_name) const {
+        for (const auto &model : _models) {
+            if (model->GetName() == model_name) {
+                return model;
+            }
+        }
+        LogError(_log_name, "Model name not found in GetModel: " + model_name);
+        throw std::invalid_argument("Error attempting to GetModel by name.");
+    }
+
     /// @brief Retrieves the names of all models in the simulation.
     /// @return Vector of model names in the order they were added.
     std::vector<std::string> GetModelNames() const {
@@ -211,49 +222,65 @@ public:
         return ret;
     }
 
-    /// @brief Retrieves the complete state histories for all models.
+    /// @brief Retrieves the complete state histories for the model at the
+    /// index.
+    /// @param idx The index of the model to retrieve histories for.
     /// @return Vector of maps (one per model) mapping history names to state
     /// vector trajectories.
-    const std::vector<std::map<std::string, std::vector<Eigen::VectorXd>>>
-    GetModelHistories() const {
-        std::vector<std::map<std::string, std::vector<Eigen::VectorXd>>> ret;
-        int model_idx = 0;
-        for (const auto &model : _models) {
-            std::map<std::string, std::vector<Eigen::VectorXd>> inner_ret;
-            for (const auto &kv : model->GetHistories()) {
-                inner_ret[kv.first] = kv.second.GetStateAsVector();
-            }
-            ret.push_back(inner_ret);
-            model_idx++;
+    const std::map<std::string, History> &GetModelHistory(size_t idx) const {
+        if (idx >= _models.size()) {
+            LogError(_log_name, "Index out of range in GetModelHistory: " +
+                                    std::to_string(idx));
+            throw std::out_of_range(
+                "Error attempting to GetModelHistory by index.");
         }
-        return ret;
+        return _models[idx]->GetHistories();
     }
 
-    /// @brief Retrieves sparse history objects for all models.
-    /// @return Vector of maps (one per model) mapping history names to sparse
-    /// History objects.
-    const std::vector<std::map<std::string, History>>
-    GetModelSparseHistories() const {
-        std::vector<std::map<std::string, History>> ret;
+    const std::map<std::string, History> &
+    GetModelHistory(const std::string &model_name) const {
         for (const auto &model : _models) {
-            ret.push_back(model->GetHistories());
+            if (model->GetName() == model_name) {
+                return model->GetHistories();
+            }
         }
-        return ret;
+        LogError(_log_name,
+                 "Model name not found in GetModelHistory: " + model_name);
+        throw std::invalid_argument(
+            "Error attempting to GetModelHistory by name.");
     }
 
     /// @brief Retrieves pairs of (model name, history name) for all histories.
     /// @return Vector of pairs associating each history with its parent model.
-    const std::vector<std::pair<std::string, std::string>>
-    GetModelHistoryNames() const {
-        std::vector<std::pair<std::string, std::string>> ret;
-        for (const auto &model : _models) {
-            for (const auto &kv : model->GetHistories()) {
-                std::pair<std::string, std::string> p = {model->GetName(),
-                                                         kv.first};
-                ret.push_back(p);
-            }
+    const std::vector<std::string> GetModelHistoryNames(size_t idx) const {
+        if (idx >= _models.size()) {
+            LogError(_log_name, "Index out of range in GetModelHistoryNames: " +
+                                    std::to_string(idx));
+            throw std::out_of_range(
+                "Error attempting to GetModelHistoryNames by index.");
+        }
+        std::vector<std::string> ret;
+        for (const auto &kv : _models[idx]->GetHistories()) {
+            ret.push_back(kv.first);
         }
         return ret;
+    }
+
+    const std::vector<std::string>
+    GetModelHistoryNames(const std::string &model_name) const {
+        for (const auto &model : _models) {
+            if (model->GetName() == model_name) {
+                std::vector<std::string> ret;
+                for (const auto &kv : model->GetHistories()) {
+                    ret.push_back(kv.first);
+                }
+                return ret;
+            }
+        }
+        LogError(_log_name,
+                 "Model name not found in GetModelHistoryNames: " + model_name);
+        throw std::invalid_argument(
+            "Error attempting to GetModelHistoryNames by name.");
     }
 
     void SetDuration(int duration) { _duration = duration; }

--- a/include/respond/timestep.hpp
+++ b/include/respond/timestep.hpp
@@ -64,7 +64,7 @@ public:
     Timestep(const Timestep &other) {
         _transitions.clear();
         for (const auto &t : other._transitions) {
-            _transitions.push_back(t->clone());
+            _transitions.push_back(std::move(t->clone()));
         }
     }
 
@@ -76,7 +76,7 @@ public:
         if (this != &other) {
             _transitions.clear();
             for (const auto &t : other._transitions) {
-                _transitions.push_back(t->clone());
+                _transitions.push_back(std::move(t->clone()));
             }
         }
         return *this;

--- a/include/respond/timestep.hpp
+++ b/include/respond/timestep.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-06-30                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -126,6 +126,11 @@ public:
         return _transitions.back();
     }
 
+    /// @brief Removes a transition from this timestep by index and returns it.
+    /// @param idx The index of the transition to remove. Must be within the
+    /// range of existing transitions.
+    /// @return A unique_ptr to the removed Transition. Throws an exception if
+    /// the index is out of range.
     std::unique_ptr<Transition> RemoveTransition(size_t idx) {
         if (idx >= _transitions.size()) {
             LogWarning(_log_name, "Index out of range in RemoveTransition: " +
@@ -146,9 +151,11 @@ public:
     void AddMatrixToTransition(const size_t &idx,
                                const Eigen::Ref<const Eigen::MatrixXd> &m) {
         if (idx >= _transitions.size()) {
-            LogWarning(_log_name,
-                       "Index out of range in AddMatrixToTransition: " +
-                           std::to_string(idx));
+            LogError(_log_name,
+                     "Index out of range in AddMatrixToTransition: " +
+                         std::to_string(idx));
+            throw std::out_of_range(
+                "Error attempting to AddMatrixToTransition by index.");
         }
         _transitions[idx]->AddMatrix(m);
     }

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-02                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-13                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -89,11 +89,35 @@ public:
            const std::string &log_name = RESPOND_DEFAULT_LOG,
            const std::string &log_file = RESPOND_DEFAULT_LOG_FILE);
 
+    /// @brief Helper function to overload to the stream insertion operator for
+    /// Transition serialization.
+    /// @details This function is intended to be overridden by subclasses to
+    /// provide custom serialization logic. It should write the transition's
+    /// state, metadata, and any relevant information to the provided output
+    /// stream.
+    /// @note The output format is implementation-defined and may vary between
+    /// subclasses. Users should refer to the specific subclass documentation
+    /// for details on the serialization format.
+    /// @param os The output stream to which the transition's serialized data
+    /// will be written.
+    virtual void Serialize(std::ostream &os) const = 0;
+
 protected:
     /// @brief Protected default constructor for subclass initialization.
     /// Not intended for direct public use.
     Transition() = default;
 };
+
+/// @brief Overloaded stream insertion operator for Model serialization.
+/// @param os The output stream to write to.
+/// @param model The Model instance to serialize.
+/// @return The output stream after writing the model's serialized data.
+inline std::ostream &operator<<(std::ostream &os,
+                                const Transition &transition) {
+    transition.Serialize(os);
+    return os;
+}
+
 } // namespace respond
 
 #endif

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -25,8 +25,6 @@
 
 namespace respond {
 
-using TransitionsVec = std::vector<std::shared_ptr<const Transition &>>;
-
 /// @brief Abstract base class representing a state transition operation.
 /// Transitions apply transformation matrices to state vectors and update
 /// history records. Subclasses define specific types of transitions (e.g.,

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -48,12 +48,11 @@ public:
     /// @brief Adds a transformation matrix to this transition.
     /// The matrix is stored for use during Execute() calls.
     /// @param m The transition matrix to add (not modified by this transition).
-    virtual void AddMatrix(const Eigen::Ref<const Eigen::MatrixXd> &m) = 0;
+    virtual void AddMatrix(Eigen::Ref<const Eigen::MatrixXd> m) = 0;
 
     /// @brief Retrieves the stored transition matrices for this transition.
     /// @return A vector of references to the stored transition matrices.
-    virtual std::vector<Eigen::Ref<const Eigen::MatrixXd>>
-    GetMatrices() const = 0;
+    virtual std::vector<Eigen::MatrixXd> GetMatrices() const = 0;
 
     /// @brief Retrieves the name/type of this transition.
     /// @return The transition's identifier as a string.

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -25,6 +25,8 @@
 
 namespace respond {
 
+using TransitionsVec = std::vector<std::shared_ptr<const Transition &>>;
+
 /// @brief Abstract base class representing a state transition operation.
 /// Transitions apply transformation matrices to state vectors and update
 /// history records. Subclasses define specific types of transitions (e.g.,

--- a/include/respond/transition.hpp
+++ b/include/respond/transition.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-02                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/include/respond/version.hpp
+++ b/include/respond/version.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-03-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-04-16                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -14,7 +14,7 @@
 #define RESPOND_VERSION_HPP_
 
 #define RESPOND_VER_MAJOR 2
-#define RESPOND_VER_MINOR 4
+#define RESPOND_VER_MINOR 5
 #define RESPOND_VER_PATCH 0
 
 #define RESPOND_TO_VERSION(major, minor, patch)                                \

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -26,11 +26,13 @@ BackgroundDeath::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
     TestCorrectNumberMatrices(1);
     TestMatrixSizes(state, GetMatrices()[0]);
     Eigen::VectorXd deaths = state.cwiseProduct(GetMatrices()[0]);
-    TestLessThanState(state, deaths);
+    TestLessThanState(state, deaths,
+                      "BackgroundDeath transition produced more deaths than "
+                      "available in state.");
+    auto new_state = state - deaths;
     if (h.find("background_death") != h.end()) {
         h["background_death"].AccumulateState(deaths);
     }
-    auto new_state = state - deaths; // remove deaths from state
     return new_state;
 }
 } // namespace respond

--- a/src/background.cpp
+++ b/src/background.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/background.hpp
+++ b/src/internals/background.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/behavior.hpp
+++ b/src/internals/behavior.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/intervention.hpp
+++ b/src/internals/intervention.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-13                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -186,10 +186,7 @@ public:
         }
     }
 
-    void RunTimestep() override {
-        RunTimestep(_current_timestep);
-        _current_timestep++;
-    }
+    void RunTimestep() override { RunTimestep(_current_timestep); }
 
     /// @brief Executes the timestep in the model's sequence.
     void RunTimestep(size_t idx) override {
@@ -211,6 +208,14 @@ public:
         for (const auto &t : transitions) {
             _state = t->Execute(_state, _histories);
         }
+        if (idx != _current_timestep) {
+            LogWarning(_log_name,
+                       "Ran timestep out of order. Current timestep: " +
+                           std::to_string(_current_timestep) +
+                           ", run timestep: " + std::to_string(idx));
+            return;
+        }
+        _current_timestep++;
     }
 
     void RunTimesteps() override {
@@ -273,6 +278,26 @@ public:
 
         _initial_history_recorded = true;
         _current_timestep = latest_timestep;
+    }
+
+    void Serialize(std::ostream &os) const override {
+        os << "Model Name: " << _name << "\n";
+        os << "Current Timestep: " << _current_timestep << "\n";
+        os << "History Capture Interval: " << _history_capture_interval << "\n";
+        os << "Final Timestep: " << _final_timestep << "\n";
+        os << "Initial History Recorded: "
+           << (_initial_history_recorded ? "true" : "false") << "\n";
+        os << "State Vector: " << _state.transpose() << "\n";
+        os << "Histories:\n";
+        for (const auto &kv : _histories) {
+            os << "  - " << kv.first << "\n";
+        }
+        os << "Timesteps:\n";
+        for (size_t i = 0; i < _timestep_vector.size(); ++i) {
+            os << "  Timestep Index: " << i << "\n";
+            os << "  Number of Transitions: "
+               << _timestep_vector[i].GetTransitions().size() << "\n";
+        }
     }
 
 private:

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -250,15 +250,15 @@ public:
     /// @return A vector of the default history objects.
     void CreateDefaultHistories() override {
         std::map<std::string, History> ret;
-        ret["state"] = History("state", _log_name, HistoryMode::Snapshot);
+        ret["state"] = History("state", _log_name, HistoryMode::kSnapshot);
         ret["total_overdose"] =
-            History("total_overdose", _log_name, HistoryMode::Accumulated);
+            History("total_overdose", _log_name, HistoryMode::kAccumulated);
         ret["fatal_overdose"] =
-            History("fatal_overdose", _log_name, HistoryMode::Accumulated);
+            History("fatal_overdose", _log_name, HistoryMode::kAccumulated);
         ret["intervention_admission"] = History(
-            "intervention_admission", _log_name, HistoryMode::Accumulated);
+            "intervention_admission", _log_name, HistoryMode::kAccumulated);
         ret["background_death"] =
-            History("background_death", _log_name, HistoryMode::Accumulated);
+            History("background_death", _log_name, HistoryMode::kAccumulated);
         _histories = ret;
         if (_histories.empty()) {
             ResetHistoryTracking();

--- a/src/internals/markov.hpp
+++ b/src/internals/markov.hpp
@@ -250,15 +250,15 @@ public:
     /// @return A vector of the default history objects.
     void CreateDefaultHistories() override {
         std::map<std::string, History> ret;
-        ret["state"] = History("state", _log_name, HistoryMode::kSnapshot);
+        ret["state"] = History("state", HistoryMode::kSnapshot, _log_name);
         ret["total_overdose"] =
-            History("total_overdose", _log_name, HistoryMode::kAccumulated);
+            History("total_overdose", HistoryMode::kAccumulated, _log_name);
         ret["fatal_overdose"] =
-            History("fatal_overdose", _log_name, HistoryMode::kAccumulated);
+            History("fatal_overdose", HistoryMode::kAccumulated, _log_name);
         ret["intervention_admission"] = History(
-            "intervention_admission", _log_name, HistoryMode::kAccumulated);
+            "intervention_admission", HistoryMode::kAccumulated, _log_name);
         ret["background_death"] =
-            History("background_death", _log_name, HistoryMode::kAccumulated);
+            History("background_death", HistoryMode::kAccumulated, _log_name);
         _histories = ret;
         if (_histories.empty()) {
             ResetHistoryTracking();
@@ -317,7 +317,7 @@ private:
             return;
         }
 
-        _histories["state"].RecordSnapshot(_state, _current_timestep);
+        _histories["state"].AddState(_state, _current_timestep);
         const auto size = _state.size();
         _histories["intervention_admission"].FlushPendingState(
             _current_timestep, size);

--- a/src/internals/migration.hpp
+++ b/src/internals/migration.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/overdose.hpp
+++ b/src/internals/overdose.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/transition_base.hpp
+++ b/src/internals/transition_base.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-13                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -44,6 +44,11 @@ public:
     std::string GetName() const override { return _name; }
     // Clear out all the stored Eigen::MatrixXd values
     void ClearMatrices() override { _transition_matrices.clear(); }
+
+    void Serialize(std::ostream &os) const override {
+        os << "Transition(name=" << _name
+           << ", num_matrices=" << _transition_matrices.size() << ")";
+    }
 
 protected:
     const std::string _log_name;

--- a/src/internals/transition_base.hpp
+++ b/src/internals/transition_base.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/internals/transition_base.hpp
+++ b/src/internals/transition_base.hpp
@@ -33,11 +33,10 @@ public:
     // Add a Transition Matrix to the set. We have no need to edit it once it's
     // been added, just use it. Thus, we don't need full ownership (reference)
     // and can accept the const type.
-    void AddMatrix(const Eigen::Ref<const Eigen::MatrixXd> &m) override {
+    void AddMatrix(Eigen::Ref<const Eigen::MatrixXd> m) override {
         _transition_matrices.push_back(m);
     }
-    std::vector<Eigen::Ref<const Eigen::MatrixXd>>
-    GetMatrices() const override {
+    std::vector<Eigen::MatrixXd> GetMatrices() const override {
         return _transition_matrices;
     }
     // Get the name of the Transition. No need to edit the object and do not
@@ -118,13 +117,17 @@ protected:
     }
 
     void TestLessThanState(const Eigen::Ref<const Eigen::MatrixXd> &state,
-                           const Eigen::Ref<const Eigen::MatrixXd> &m1) const {
+                           const Eigen::Ref<const Eigen::MatrixXd> &m1,
+                           std::string extra_msg = "") const {
         if (!(state.array() >= m1.array()).all()) {
             std::string error_msg =
                 "Transition error - State contains values less than m1! " +
                 std::to_string((state.array() < m1.array()).count()) +
                 " elements affected. Verify that the transition matrix is "
                 "correct and that the state vector is valid.";
+            if (!extra_msg.empty()) {
+                error_msg += " " + extra_msg;
+            }
             LogError(_log_name, error_msg);
             throw std::runtime_error(error_msg);
         }
@@ -132,7 +135,7 @@ protected:
 
 private:
     std::string _name;
-    std::vector<Eigen::Ref<const Eigen::MatrixXd>> _transition_matrices;
+    std::vector<Eigen::MatrixXd> _transition_matrices;
 };
 
 } // namespace respond

--- a/src/intervention.cpp
+++ b/src/intervention.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-06-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-06-30                                                  //
+// Last Modified: 2026-07-09                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -21,7 +21,6 @@ namespace respond {
 CreationStatus CreateFileLogger(const std::string &logger_name,
                                 const std::string &filepath) {
     if (CheckIfExists(logger_name) == CreationStatus::kExists) {
-        std::cout << "Logger " << logger_name << " already exists" << std::endl;
         return CreationStatus::kExists;
     }
     try {

--- a/src/migration.cpp
+++ b/src/migration.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/overdose.cpp
+++ b/src/overdose.cpp
@@ -23,6 +23,7 @@ Eigen::VectorXd
 Overdose::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
                   std::map<std::string, History> &h) const {
     TestCorrectNumberMatrices(2);
+    auto matrices = GetMatrices();
 
     TestMatrixSizes(state, GetMatrices()[0]);
     Eigen::VectorXd overdoses = state.cwiseProduct(GetMatrices()[0]);
@@ -34,7 +35,7 @@ Overdose::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
     }
 
     TestMatrixSizes(overdoses, GetMatrices()[1]);
-    auto fods = overdoses.cwiseProduct(GetMatrices()[1]); // negatives
+    Eigen::VectorXd fods = overdoses.cwiseProduct(GetMatrices()[1]);
     TestLessThanState(state, fods,
                       "Overdose transition produced more fatal overdoses than "
                       "available in state.");

--- a/src/overdose.cpp
+++ b/src/overdose.cpp
@@ -26,17 +26,22 @@ Overdose::Execute(const Eigen::Ref<const Eigen::VectorXd> &state,
 
     TestMatrixSizes(state, GetMatrices()[0]);
     Eigen::VectorXd overdoses = state.cwiseProduct(GetMatrices()[0]);
+    TestLessThanState(state, overdoses,
+                      "Overdose transition produced more total overdoses than "
+                      "available in state.");
     if (h.find("total_overdose") != h.end()) {
         h["total_overdose"].AccumulateState(overdoses);
     }
 
     TestMatrixSizes(overdoses, GetMatrices()[1]);
     auto fods = overdoses.cwiseProduct(GetMatrices()[1]); // negatives
+    TestLessThanState(state, fods,
+                      "Overdose transition produced more fatal overdoses than "
+                      "available in state.");
+    auto new_state = state - fods;
     if (h.find("fatal_overdose") != h.end()) {
         h["fatal_overdose"].AccumulateState(fods);
     }
-    TestLessThanState(state, fods);
-    auto new_state = state - fods; // remove fods from state
     return new_state;
 }
 } // namespace respond

--- a/src/overdose.cpp
+++ b/src/overdose.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/src/transition_factory.cpp
+++ b/src/transition_factory.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-07                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -49,6 +49,6 @@ std::unique_ptr<Transition> Transition::Create(const std::string &type,
                             "'. Supported types: migration, behavior, "
                             "intervention, overdose, background_death";
     LogError(log_name, error_msg);
-    return nullptr;
+    throw std::invalid_argument(error_msg);
 }
 } // namespace respond

--- a/tests/integration/respond_test.cpp
+++ b/tests/integration/respond_test.cpp
@@ -93,7 +93,8 @@ protected:
 TEST_F(RespondTest, RunSingleTimestep) {
     sim.GetModels()[0]->AddTimestep(CreateTestTimestep());
     sim.Run();
-    Eigen::VectorXd result = sim.GetModelHistories()[0].at("state").back();
+    Eigen::VectorXd result =
+        sim.GetModelHistory(0).at("state").GetStateAsVector().back();
 
     Eigen::Vector3d final_state;
     final_state << 0.76715528791564891, 0.72320370216816077, 1.037712429738102;
@@ -105,15 +106,7 @@ TEST_F(RespondTest, RunSimulationTwoStep) {
     sim.GetModels()[0]->AddTimestep(CreateTestTimestep());
     sim.Run(2);
 
-    auto histories = sim.GetModelHistories();
-    ASSERT_EQ(histories.size(), 1);
-
-    auto mm_histories = histories[0];
-    if (mm_histories.find("state") == mm_histories.end()) {
-        FAIL() << "Unable to find the 'state' history.";
-    }
-
-    auto state_history = mm_histories.at("state");
+    auto state_history = sim.GetModelHistory(0).at("state").GetStateAsVector();
     // 2 because it carries the initial state and 2 steps
     ASSERT_EQ(state_history.size(), 3);
 
@@ -134,15 +127,7 @@ TEST_F(RespondTest, RunSimulationFiveStep) {
     sim.SetDuration(5);
     sim.Run();
 
-    auto histories = sim.GetModelHistories();
-    ASSERT_EQ(histories.size(), 1);
-
-    auto mm_histories = histories[0];
-    if (mm_histories.find("state") == mm_histories.end()) {
-        FAIL() << "Unable to find the 'state' history.";
-    }
-
-    auto state_history = mm_histories.at("state");
+    auto state_history = sim.GetModelHistory(0).at("state").GetStateAsVector();
     // 6 because it carries the initial state and 5 timesteps
     ASSERT_EQ(state_history.size(), 6);
 
@@ -162,15 +147,7 @@ TEST_F(RespondTest, RunSimulationFiveStepWithDurationParameter) {
     sim.GetModels()[0]->AddTimestep(CreateTestTimestep());
     sim.Run(5);
 
-    auto histories = sim.GetModelHistories();
-    ASSERT_EQ(histories.size(), 1);
-
-    auto mm_histories = histories[0];
-    if (mm_histories.find("state") == mm_histories.end()) {
-        FAIL() << "Unable to find the 'state' history.";
-    }
-
-    auto state_history = mm_histories.at("state");
+    auto state_history = sim.GetModelHistory(0).at("state").GetStateAsVector();
     // 6 because it carries the initial state and 5 timesteps
     ASSERT_EQ(state_history.size(), 6);
 

--- a/tests/mocks/model_mock.hpp
+++ b/tests/mocks/model_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-08-01                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -52,6 +53,7 @@ public:
     MOCK_METHOD(void, SetHistoryCaptureInterval, (int), (override));
     MOCK_METHOD(void, SetFinalTimestep, (int), (override));
     MOCK_METHOD(void, SetInitialHistoryRecorded, (bool), (override));
+    MOCK_METHOD(void, Serialize, (std::ostream &), (const, override));
 };
 } // namespace testing
 } // namespace respond

--- a/tests/mocks/transition_mock.hpp
+++ b/tests/mocks/transition_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-07                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -30,10 +30,10 @@ public:
                 ((const Eigen::Ref<const Eigen::VectorXd> &),
                  (std::map<std::string, History> &)),
                 (const, override));
-    MOCK_METHOD(void, AddMatrix, (const Eigen::Ref<const Eigen::MatrixXd> &),
+    MOCK_METHOD(void, AddMatrix, (Eigen::Ref<const Eigen::MatrixXd>),
                 (override));
-    MOCK_METHOD((std::vector<Eigen::Ref<const Eigen::MatrixXd>>), GetMatrices,
-                (), (const, override));
+    MOCK_METHOD((std::vector<Eigen::MatrixXd>), GetMatrices, (),
+                (const, override));
     MOCK_METHOD(void, ClearMatrices, (), (override));
     MOCK_METHOD(std::string, GetName, (), (const, override));
     MOCK_METHOD(std::unique_ptr<Transition>, clone, (), (const, override));

--- a/tests/mocks/transition_mock.hpp
+++ b/tests/mocks/transition_mock.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-13                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <memory>
+#include <ostream>
 #include <vector>
 
 #include <Eigen/Dense>
@@ -37,6 +38,7 @@ public:
     MOCK_METHOD(void, ClearMatrices, (), (override));
     MOCK_METHOD(std::string, GetName, (), (const, override));
     MOCK_METHOD(std::unique_ptr<Transition>, clone, (), (const, override));
+    MOCK_METHOD(void, Serialize, (std::ostream &), (const, override));
 };
 } // namespace testing
 } // namespace respond

--- a/tests/unit/background_test.cpp
+++ b/tests/unit/background_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/tests/unit/behavior_test.cpp
+++ b/tests/unit/behavior_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/tests/unit/history_test.cpp
+++ b/tests/unit/history_test.cpp
@@ -4,87 +4,178 @@
 // Created Date: 2026-05-05                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <respond/history.hpp>
 
+#include <fstream>
 #include <vector>
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
+#include <spdlog/spdlog.h>
 
 namespace respond {
 namespace testing {
 
-TEST(HistoryTest, SparseStoragePreservesRecordedTimesteps) {
-    History history("state", "test_logger");
-    Eigen::VectorXd state0(2);
-    state0 << 1.0f, 2.0f;
+class HistoryTest : public ::testing::Test {
+public:
+protected:
+    void SetUp() override {
+        // Clear any existing loggers from previous tests
+        spdlog::drop_all();
+
+        // Create temporary log files for testing
+        default_log_file_ = RESPOND_DEFAULT_LOG_FILE;
+
+        // Remove test files if they exist
+        std::remove(default_log_file_.c_str());
+    }
+    void TearDown() override {
+        // Clean up loggers
+        spdlog::drop_all();
+
+        // Remove test files
+        std::remove(default_log_file_.c_str());
+    }
+
+    std::string default_log_file_;
+
+    // Helper to check if file contains a string
+    bool FileContains(const std::string &filepath, const std::string &search) {
+        std::ifstream file(filepath);
+        if (!file.is_open())
+            return false;
+
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.find(search) != std::string::npos) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+TEST_F(HistoryTest, GetDefaultHistoryModeReturnsAccumulatedForSpecificNames) {
+    EXPECT_EQ(GetDefaultHistoryMode("intervention_admission"),
+              HistoryMode::kAccumulated);
+    EXPECT_EQ(GetDefaultHistoryMode("total_overdose"),
+              HistoryMode::kAccumulated);
+    EXPECT_EQ(GetDefaultHistoryMode("fatal_overdose"),
+              HistoryMode::kAccumulated);
+    EXPECT_EQ(GetDefaultHistoryMode("background_death"),
+              HistoryMode::kAccumulated);
+}
+
+TEST_F(HistoryTest, GetDefaultHistoryModeReturnsSnapshotForOtherNames) {
+    EXPECT_EQ(GetDefaultHistoryMode("state"), HistoryMode::kSnapshot);
+    EXPECT_EQ(GetDefaultHistoryMode("custom_history"), HistoryMode::kSnapshot);
+    EXPECT_EQ(GetDefaultHistoryMode(""), HistoryMode::kSnapshot);
+}
+
+TEST_F(HistoryTest, DefaultConstructor) {
+    History history;
+    EXPECT_EQ(history.GetName(), "state");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kSnapshot);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, ConstructorWithName) {
+    History history("custom_history");
+    EXPECT_EQ(history.GetName(), "custom_history");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kSnapshot);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, ConstructorWithNameAndMode) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    EXPECT_EQ(history.GetName(), "total_overdose");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kAccumulated);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, ConstructorWithNameModeAndLogger) {
+    History history("fatal_overdose", HistoryMode::kAccumulated, "test_logger");
+    EXPECT_EQ(history.GetName(), "fatal_overdose");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kAccumulated);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, ConstructorWithNameAndLogger) {
+    History history("background_death", "test_logger");
+    EXPECT_EQ(history.GetName(), "background_death");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kAccumulated);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, ConstructorWithNameModeLoggerAndLogFile) {
+    History history("background_death", HistoryMode::kAccumulated,
+                    "test_logger", default_log_file_);
+    EXPECT_EQ(history.GetName(), "background_death");
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kAccumulated);
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, EqualityOperator) {
+    History history("state");
+    History history_copy("state");
+
+    history.AddState(Eigen::VectorXd::Ones(2), 0);
+    history_copy.AddState(Eigen::VectorXd::Ones(2), 0);
+    EXPECT_EQ(history, history_copy);
+}
+
+TEST_F(HistoryTest, InequalityOperator) {
+    History history("state");
+    History history_copy("state");
+
+    history.AddState(Eigen::VectorXd::Ones(2), 0);
+    history_copy.AddState(Eigen::VectorXd::Zero(2), 0);
+    EXPECT_NE(history, history_copy);
+}
+
+TEST_F(HistoryTest, AddStateRecordsStateAtSpecifiedTimestep) {
+    History history("state");
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
+
+    history.AddState(state, 5);
+
+    std::vector<int> expected_timesteps = {5};
+    ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
+    ASSERT_EQ(history.GetRecordedStates().size(), 1u);
+    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(state));
+}
+
+TEST_F(HistoryTest, AddStateRecordsStateAtNextSequentialTimestep) {
+    History history("state");
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
     Eigen::VectorXd state2(2);
     state2 << 3.0f, 4.0f;
 
-    history.AddState(state0, 0);
-    history.AddState(state2, 2);
+    history.AddState(state1); // Should be at timestep 0
+    history.AddState(state2); // Should be at timestep 1
 
-    std::vector<int> expected_timesteps = {0, 2};
+    std::vector<int> expected_timesteps = {0, 1};
     ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
     ASSERT_EQ(history.GetRecordedStates().size(), 2u);
-    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(state0));
+    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(state1));
     EXPECT_TRUE(history.GetRecordedStates()[1].isApprox(state2));
 }
 
-TEST(HistoryTest, GetStateAsVectorFillsSparseGapsWithZeros) {
-    History history("state", "test_logger");
-    Eigen::VectorXd state0(2);
-    state0 << 1.0f, 2.0f;
-    Eigen::VectorXd state2(2);
-    state2 << 3.0f, 4.0f;
-
-    history.AddState(state0, 0);
-    history.AddState(state2, 2);
-
-    const auto dense_states = history.GetStateAsVector();
-    ASSERT_EQ(dense_states.size(), 3u);
-    EXPECT_TRUE(dense_states[0].isApprox(state0));
-    EXPECT_TRUE(dense_states[1].isZero());
-    EXPECT_TRUE(dense_states[2].isApprox(state2));
-}
-
-TEST(HistoryTest, GetStateMapBuildsSparseMapOnDemand) {
-    History history("state", "test_logger");
-    Eigen::VectorXd state0(1);
-    state0 << 5.0f;
-    Eigen::VectorXd state3(1);
-    state3 << 7.0f;
-
-    history.AddState(state0, 0);
-    history.AddState(state3, 3);
-
-    const auto state_map = history.GetStateMap();
-    ASSERT_EQ(state_map.size(), 2u);
-    EXPECT_TRUE(state_map.at(0).isApprox(state0));
-    EXPECT_TRUE(state_map.at(3).isApprox(state3));
-}
-
-TEST(HistoryTest, ClearRemovesRecordedStatesAndTimesteps) {
-    History history("state", "test_logger");
-    Eigen::VectorXd state(1);
-    state << 1.0f;
-    history.AddState(state, 0);
-
-    history.Clear();
-
-    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
-    EXPECT_TRUE(history.GetRecordedStates().empty());
-    EXPECT_TRUE(history.GetStateAsVector().empty());
-    EXPECT_TRUE(history.GetStateMap().empty());
-}
-
-TEST(HistoryTest, AccumulatedHistoryFlushesPendingState) {
-    History history("total_overdose", "test_logger", HistoryMode::kAccumulated);
+TEST_F(HistoryTest, AccumulateStateAddsToPendingState) {
+    History history("total_overdose", HistoryMode::kAccumulated);
     Eigen::VectorXd first(2);
     first << 1.0f, 2.0f;
     Eigen::VectorXd second(2);
@@ -92,10 +183,41 @@ TEST(HistoryTest, AccumulatedHistoryFlushesPendingState) {
 
     history.AccumulateState(first);
     history.AccumulateState(second);
-    history.FlushPendingState(4, 2);
+
+    Eigen::VectorXd expected(2);
+    expected << 4.0f, 6.0f;
+    EXPECT_TRUE(history.GetPendingState().isApprox(expected));
+}
+
+TEST_F(HistoryTest, AccumulateStateOnNonAccumulatedHistoryAddsState) {
+    History history("state", HistoryMode::kSnapshot);
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
+
+    history.AccumulateState(state);
+
+    std::vector<int> expected_timesteps = {0};
+    ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
+    ASSERT_EQ(history.GetRecordedStates().size(), 1u);
+    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(state));
+    FlushAllLoggers();
+    EXPECT_TRUE(FileContains(RESPOND_DEFAULT_LOG_FILE,
+                             "AccumulateState called on non-accumulated"));
+}
+
+TEST_F(HistoryTest, FlushPendingStateRecordsPendingStateAtSpecifiedTimestep) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    Eigen::VectorXd first(2);
+    first << 1.0f, 2.0f;
+    Eigen::VectorXd second(2);
+    second << 3.0f, 4.0f;
+
+    history.AccumulateState(first);
+    history.AccumulateState(second);
+    history.FlushPendingState(10, 2);
 
     ASSERT_FALSE(history.HasPendingState());
-    std::vector<int> expected_timesteps = {4};
+    std::vector<int> expected_timesteps = {10};
     ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
 
     Eigen::VectorXd expected(2);
@@ -104,16 +226,189 @@ TEST(HistoryTest, AccumulatedHistoryFlushesPendingState) {
     EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(expected));
 }
 
-TEST(HistoryTest, AccumulatedHistoryFlushesZeroWhenNoPendingStateExists) {
-    History history("background_death", "test_logger",
-                    HistoryMode::kAccumulated);
+TEST_F(HistoryTest, FlushPendingStateOnNonAccumulatedHistoryDoesNothing) {
+    History history("state", HistoryMode::kSnapshot);
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
 
-    history.FlushPendingState(0, 3);
+    history.AccumulateState(state);  // Should add state instead
+    history.FlushPendingState(5, 2); // Should do nothing
 
     std::vector<int> expected_timesteps = {0};
     ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
     ASSERT_EQ(history.GetRecordedStates().size(), 1u);
-    EXPECT_TRUE(history.GetRecordedStates()[0].isZero());
+    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(state));
+    FlushAllLoggers();
+    EXPECT_TRUE(
+        FileContains(RESPOND_DEFAULT_LOG_FILE,
+                     "FlushPendingState called on non-accumulated history"));
+}
+
+TEST_F(HistoryTest, FlushPendingStateWithNoPendingStateRecordsZeroVector) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    history.FlushPendingState(3, 2);
+
+    std::vector<int> expected_timesteps = {3};
+    ASSERT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
+    ASSERT_EQ(history.GetRecordedStates().size(), 1u);
+
+    Eigen::VectorXd expected = Eigen::VectorXd::Zero(2);
+    EXPECT_TRUE(history.GetRecordedStates()[0].isApprox(expected));
+}
+
+TEST_F(HistoryTest, ClearEmptiesHistory) {
+    History history("state");
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
+
+    history.AddState(state, 0);
+    ASSERT_FALSE(history.GetRecordedTimesteps().empty());
+    ASSERT_FALSE(history.GetRecordedStates().empty());
+
+    history.Clear();
+    EXPECT_TRUE(history.GetRecordedTimesteps().empty());
+    EXPECT_TRUE(history.GetRecordedStates().empty());
+}
+
+TEST_F(HistoryTest, HasPendingStateReturnsTrueWhenPending) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
+
+    EXPECT_FALSE(history.HasPendingState());
+    history.AccumulateState(state);
+    EXPECT_TRUE(history.HasPendingState());
+}
+
+TEST_F(HistoryTest, HasPendingStateReturnsFalseWhenNoPending) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    EXPECT_FALSE(history.HasPendingState());
+}
+
+TEST_F(HistoryTest, GetStateMap) {
+    History history("state");
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
+    Eigen::VectorXd state2(2);
+    state2 << 3.0f, 4.0f;
+
+    history.AddState(state1, 5);
+    history.AddState(state2, 10);
+
+    std::map<int, Eigen::VectorXd> expected_map = {{5, state1}, {10, state2}};
+
+    auto state_map = history.GetStateMap();
+    ASSERT_EQ(state_map.size(), expected_map.size());
+    for (const auto &[timestep, expected_state] : expected_map) {
+        ASSERT_TRUE(state_map.find(timestep) != state_map.end());
+        EXPECT_TRUE(state_map[timestep].isApprox(expected_state));
+    }
+}
+
+TEST_F(HistoryTest, GetRecordedTimesteps) {
+    History history("state");
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
+    Eigen::VectorXd state2(2);
+    state2 << 3.0f, 4.0f;
+
+    history.AddState(state1, 5);
+    history.AddState(state2, 10);
+
+    std::vector<int> expected_timesteps = {5, 10};
+    EXPECT_EQ(history.GetRecordedTimesteps(), expected_timesteps);
+}
+
+TEST_F(HistoryTest, GetRecordedStates) {
+    History history("state");
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
+    Eigen::VectorXd state2(2);
+    state2 << 3.0f, 4.0f;
+
+    history.AddState(state1, 5);
+    history.AddState(state2, 10);
+
+    const auto &recorded_states = history.GetRecordedStates();
+    ASSERT_EQ(recorded_states.size(), 2u);
+    EXPECT_TRUE(recorded_states[0].isApprox(state1));
+    EXPECT_TRUE(recorded_states[1].isApprox(state2));
+}
+
+TEST_F(HistoryTest, GetHistoryMode) {
+    History history("state", HistoryMode::kSnapshot);
+    EXPECT_EQ(history.GetHistoryMode(), HistoryMode::kSnapshot);
+
+    History history2("total_overdose", HistoryMode::kAccumulated);
+    EXPECT_EQ(history2.GetHistoryMode(), HistoryMode::kAccumulated);
+}
+
+TEST_F(HistoryTest, GetPendingState) {
+    History history("total_overdose", HistoryMode::kAccumulated);
+    Eigen::VectorXd state(2);
+    state << 1.0f, 2.0f;
+
+    EXPECT_TRUE(history.GetPendingState().size() == 0);
+    history.AccumulateState(state);
+    EXPECT_TRUE(history.GetPendingState().isApprox(state));
+}
+
+TEST_F(HistoryTest, GetLatestRecordedTimestep) {
+    History history("state");
+    EXPECT_EQ(history.GetLatestRecordedTimestep(), -1);
+
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
+    Eigen::VectorXd state2(2);
+    state2 << 3.0f, 4.0f;
+
+    history.AddState(state1, 5);
+    history.AddState(state2, 10);
+
+    EXPECT_EQ(history.GetLatestRecordedTimestep(), 10);
+}
+
+TEST_F(HistoryTest, GetLatestRecordedTimestepOnEmptyHistoryReturnsNegativeOne) {
+    History history("state");
+    EXPECT_EQ(history.GetLatestRecordedTimestep(), -1);
+    FlushAllLoggers();
+    EXPECT_TRUE(
+        FileContains(RESPOND_DEFAULT_LOG_FILE,
+                     "GetLatestRecordedTimestep called on empty history"));
+}
+
+TEST_F(HistoryTest, GetName) {
+    History history("custom_history");
+    EXPECT_EQ(history.GetName(), "custom_history");
+}
+
+TEST_F(HistoryTest, GetStateAsVectorFillsGapsWithZeroVectors) {
+    History history("state");
+    Eigen::VectorXd state1(2);
+    state1 << 1.0f, 2.0f;
+    Eigen::VectorXd state2(2);
+    state2 << 3.0f, 4.0f;
+
+    history.AddState(state1, 0);
+    history.AddState(state2, 3);
+
+    std::vector<Eigen::VectorXd> expected_states = {
+        state1, Eigen::VectorXd::Zero(2), Eigen::VectorXd::Zero(2), state2};
+
+    auto state_vector = history.GetStateAsVector();
+    ASSERT_EQ(state_vector.size(), expected_states.size());
+    for (size_t i = 0; i < expected_states.size(); ++i) {
+        EXPECT_TRUE(state_vector[i].isApprox(expected_states[i]));
+    }
+}
+
+TEST_F(HistoryTest, GetStateAsVectorOnEmptyHistoryReturnsEmptyVector) {
+    History history("state");
+    auto state_vector = history.GetStateAsVector();
+    EXPECT_TRUE(state_vector.empty());
+    FlushAllLoggers();
+    EXPECT_TRUE(FileContains(RESPOND_DEFAULT_LOG_FILE,
+                             "GetStateAsVector called on empty history:"));
 }
 
 } // namespace testing

--- a/tests/unit/history_test.cpp
+++ b/tests/unit/history_test.cpp
@@ -2,10 +2,10 @@
 // File: history_test.cpp                                                     //
 // Project: respond                                                           //
 // Created Date: 2026-05-05                                                   //
-// Author: GitHub Copilot                                                     //
+// Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-05-05                                                  //
-// Modified By: GitHub Copilot                                                //
+// Last Modified: 2026-07-09                                                  //
+// Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -84,7 +84,7 @@ TEST(HistoryTest, ClearRemovesRecordedStatesAndTimesteps) {
 }
 
 TEST(HistoryTest, AccumulatedHistoryFlushesPendingState) {
-    History history("total_overdose", "test_logger", HistoryMode::Accumulated);
+    History history("total_overdose", "test_logger", HistoryMode::kAccumulated);
     Eigen::VectorXd first(2);
     first << 1.0f, 2.0f;
     Eigen::VectorXd second(2);
@@ -106,7 +106,7 @@ TEST(HistoryTest, AccumulatedHistoryFlushesPendingState) {
 
 TEST(HistoryTest, AccumulatedHistoryFlushesZeroWhenNoPendingStateExists) {
     History history("background_death", "test_logger",
-                    HistoryMode::Accumulated);
+                    HistoryMode::kAccumulated);
 
     history.FlushPendingState(0, 3);
 

--- a/tests/unit/intervention_test.cpp
+++ b/tests/unit/intervention_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/tests/unit/logging_test.cpp
+++ b/tests/unit/logging_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2025-03-18                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-09                                                  //
+// Last Modified: 2026-07-14                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2025-2026 Syndemics Lab at Boston Medical Center             //
@@ -495,11 +495,11 @@ TEST_F(LoggingTest, MixedFileAndSharedLoggers) {
 TEST_F(LoggingTest, TransitionFactoryInvalidType) {
     CreateFileLogger("factory_test", test_log_file_);
 
-    // Create transition with invalid type should log error and return nullptr
-    auto transition =
-        respond::Transition::Create("invalid_type", "factory_test");
-
-    EXPECT_EQ(transition, nullptr);
+    // Create transition with invalid type should log error and throw error
+    EXPECT_THROW(
+        (void)respond::Transition::Create("invalid_type", "factory_test"),
+        std::invalid_argument);
+    FlushAllLoggers();
     EXPECT_EQ(CheckLoggerExists("factory_test"), CreationStatus::kExists);
 }
 

--- a/tests/unit/migration_test.cpp
+++ b/tests/unit/migration_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/tests/unit/overdose_test.cpp
+++ b/tests/unit/overdose_test.cpp
@@ -14,6 +14,7 @@
 #include <respond/transition.hpp>
 
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <string>
@@ -141,13 +142,15 @@ TEST_F(OverdoseTest, ExecuteValid) {
     Overdose overdose;
     overdose.AddMatrix(tran_matrix);
     overdose.AddMatrix(tran_matrix);
+
     histories["state"] = History("state");
     Eigen::VectorXd result = overdose.Execute(state, histories);
-
     Eigen::VectorXd expected_overdoses = state.cwiseProduct(tran_matrix);
+
     Eigen::VectorXd expected_fods =
         expected_overdoses.cwiseProduct(tran_matrix);
     Eigen::VectorXd expected_new_state = state - expected_fods;
+
     EXPECT_TRUE(result.isApprox(expected_new_state));
 }
 

--- a/tests/unit/overdose_test.cpp
+++ b/tests/unit/overdose_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-06                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //

--- a/tests/unit/simulation_test.cpp
+++ b/tests/unit/simulation_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-13                                                  //
+// Last Modified: 2026-07-15                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -249,15 +249,18 @@ TEST_F(SimulationTest, GetModelHistoryNames) {
     auto cloned2 = std::make_unique<NiceMock<MockModel>>();
     auto *cloned2_ptr = cloned2.get();
     EXPECT_CALL(*cloned2_ptr, GetName()).WillRepeatedly(Return("model2"));
-    EXPECT_CALL(*cloned2_ptr, GetHistories()).Times(0);
+    EXPECT_CALL(*cloned2_ptr, GetHistories()).WillOnce(ReturnRef(histories2));
     EXPECT_CALL(*mock_model2, clone())
         .WillOnce(Return(::testing::ByMove(std::move(cloned2))));
     s.AddModel(std::move(mock_model2));
 
     const auto history_names = s.GetModelHistoryNames(0);
     const std::vector<std::string> expected = {"history1", "history2"};
-
     ASSERT_EQ(history_names, expected);
+
+    const auto history_names_two = s.GetModelHistoryNames(1);
+    const std::vector<std::string> expected_two = {"history3"};
+    ASSERT_EQ(history_names_two, expected_two);
 }
 
 } // namespace testing

--- a/tests/unit/simulation_test.cpp
+++ b/tests/unit/simulation_test.cpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-02-09                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-08                                                  //
+// Last Modified: 2026-07-13                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -218,53 +218,15 @@ TEST_F(SimulationTest, GetModelHistories) {
         .WillOnce(Return(::testing::ByMove(std::move(cloned))));
     s.AddModel(std::move(mock_model));
 
-    const auto model_histories = s.GetModelHistories();
+    const auto model_histories = s.GetModelHistory(0);
     ASSERT_EQ(model_histories.size(), 1);
-    ASSERT_EQ(model_histories[0].size(), 1);
+    ASSERT_EQ(model_histories.size(), 1);
 
-    const auto history_it = model_histories[0].find("history1");
-    ASSERT_NE(history_it, model_histories[0].end());
-    ASSERT_EQ(history_it->second.size(), 3);
-    EXPECT_TRUE(history_it->second[0].isApprox(state0));
-    EXPECT_TRUE(history_it->second[1].isApprox(Eigen::VectorXd::Zero(2)));
-    EXPECT_TRUE(history_it->second[2].isApprox(state2));
-}
-
-TEST_F(SimulationTest, GetModelSparseHistories) {
-    Simulation s;
-
-    History history1("history1");
-    Eigen::VectorXd state1(2);
-    state1 << 5.0, 6.0;
-    history1.AddState(state1, 1);
-
-    History history2("history2");
-    Eigen::VectorXd state2(2);
-    state2 << 7.0, 8.0;
-    history2.AddState(state2, 3);
-
-    auto histories = std::map<std::string, History>{{"history1", history1},
-                                                    {"history2", history2}};
-
-    auto mock_model = std::make_unique<NiceMock<MockModel>>();
-    auto cloned = std::make_unique<NiceMock<MockModel>>();
-    auto *cloned_ptr = cloned.get();
-    EXPECT_CALL(*cloned_ptr, GetHistories()).WillOnce(ReturnRef(histories));
-    EXPECT_CALL(*mock_model, clone())
-        .WillOnce(Return(::testing::ByMove(std::move(cloned))));
-    s.AddModel(std::move(mock_model));
-
-    const auto sparse_histories = s.GetModelSparseHistories();
-    ASSERT_EQ(sparse_histories.size(), 1);
-    ASSERT_EQ(sparse_histories[0].size(), 2);
-
-    const auto history1_it = sparse_histories[0].find("history1");
-    ASSERT_NE(history1_it, sparse_histories[0].end());
-    EXPECT_EQ(history1_it->second, history1);
-
-    const auto history2_it = sparse_histories[0].find("history2");
-    ASSERT_NE(history2_it, sparse_histories[0].end());
-    EXPECT_EQ(history2_it->second, history2);
+    const auto history_it = model_histories.at("history1").GetStateAsVector();
+    ASSERT_EQ(history_it.size(), 3);
+    EXPECT_TRUE(history_it[0].isApprox(state0));
+    EXPECT_TRUE(history_it[1].isApprox(Eigen::VectorXd::Zero(2)));
+    EXPECT_TRUE(history_it[2].isApprox(state2));
 }
 
 TEST_F(SimulationTest, GetModelHistoryNames) {
@@ -287,17 +249,13 @@ TEST_F(SimulationTest, GetModelHistoryNames) {
     auto cloned2 = std::make_unique<NiceMock<MockModel>>();
     auto *cloned2_ptr = cloned2.get();
     EXPECT_CALL(*cloned2_ptr, GetName()).WillRepeatedly(Return("model2"));
-    EXPECT_CALL(*cloned2_ptr, GetHistories()).WillOnce(ReturnRef(histories2));
+    EXPECT_CALL(*cloned2_ptr, GetHistories()).Times(0);
     EXPECT_CALL(*mock_model2, clone())
         .WillOnce(Return(::testing::ByMove(std::move(cloned2))));
     s.AddModel(std::move(mock_model2));
 
-    const auto history_names = s.GetModelHistoryNames();
-    const std::vector<std::pair<std::string, std::string>> expected = {
-        {"model1", "history1"},
-        {"model1", "history2"},
-        {"model2", "history3"},
-    };
+    const auto history_names = s.GetModelHistoryNames(0);
+    const std::vector<std::string> expected = {"history1", "history2"};
 
     ASSERT_EQ(history_names, expected);
 }


### PR DESCRIPTION
## What does this PR do?

This PR addresses limitations to the History object and document discrepancies. Specifically:

- We completely restructure history tests
- UML, README, architecture, etc. documentation has been updated to reflect new timestep class
- operator overloading for ostreams and the Serialize abstract function has been added to transitions and models to allow for easier printing
- Getting History objects has been streamlined to allow for retrieving history as needed rather than grabbing all history from all models
- GetModel now has a parameter to define the parameter rather than returning the entire list

## What Wrike task is this associated with?

https://www.wrike.com/open.htm?id=4508183000
https://www.wrike.com/open.htm?id=4508182915
https://www.wrike.com/open.htm?id=4506516494

## Checklist before merging

- [x] If adding a core feature, I've added related tests.
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
