### PR TITLE
[Feature] Timestep Index Operator

### DIFF
--- a/docs/src/api-guide.md
+++ b/docs/src/api-guide.md
@@ -51,8 +51,14 @@ model->SetState(initial_state);
 
 // Build one timestep with transitions
 respond::Timestep step("logger_name");
-auto &transition = step.CreateTransition("behavior");
-transition->AddMatrix(some_matrix);
+auto &behavior_transition = step.CreateTransition("behavior");
+behavior_transition->AddMatrix(some_matrix);
+
+auto migration_transition = respond::Transition::Create("migration");
+step.AddTransition(migration_transition);
+
+// Mutable index access to owned transition slots
+step[0]->AddMatrix(some_other_matrix);
 model->AddTimestep(step);
 
 // Execute one simulation step
@@ -125,6 +131,48 @@ auto history_names = sim.GetModelHistoryNames(0);
 - `ClearModels()`: Removes all models
 - `GetModelHistory(size_t idx) const`: Returns one model's history map
 - `GetModelHistoryNames(size_t idx) const`: Returns history names for one model
+
+## Timestep Class
+
+The Timestep class owns transitions for one model step and supports both
+transition creation and clone-based insertion.
+
+```cpp
+#include <respond/timestep.hpp>
+#include <respond/transition.hpp>
+
+respond::Timestep step("my_logger");
+
+// Build transition in-place
+auto &behavior = step.CreateTransition("behavior");
+behavior->AddMatrix(behavior_matrix);
+
+// Add an existing transition by clone
+auto migration = respond::Transition::Create("migration");
+step.AddTransition(migration);
+
+// Mutable slot access (in-place edits)
+step[0]->AddMatrix(another_behavior_matrix);
+
+// Replace a slot by cloning from another slot or transition pointer
+step[1] = step[0];
+step[1] = migration;
+
+// Const slot access
+const respond::Timestep &const_step = step;
+const respond::Transition &t = const_step[0];
+```
+
+### Key Methods
+
+- `CreateTransition(const std::string &transition_name)`: Creates and stores a transition by type
+- `AddTransition(const std::unique_ptr<Transition> &transition)`: Clones and stores caller-provided transition
+- `operator[](size_t idx)`: Mutable slot access for transition mutation/replacement
+- `operator[](size_t idx) const`: Const transition reference by index
+- `GetTransition(const size_t &idx) const`: Gets transition pointer by index
+- `GetTransition(const std::string &transition_name) const`: Gets transition pointer by name
+- `GetTransitionNames() const`: Returns transition names in execution order
+- `RemoveTransition(size_t idx)`: Removes and returns transition at index
 
 ### Model Access Semantics
 

--- a/docs/src/run.md
+++ b/docs/src/run.md
@@ -38,8 +38,14 @@ int main() {
     
     // Build one timestep and attach transitions
     respond::Timestep step("my_logger");
-    auto &transition = step.CreateTransition("behavior");
-    // transition->AddMatrix(...);
+    auto &behavior = step.CreateTransition("behavior");
+    // behavior->AddMatrix(...);
+
+    auto migration = respond::Transition::Create("migration");
+    step.AddTransition(migration);
+
+    // Mutable slot access to transitions owned by this timestep
+    // step[0]->AddMatrix(...);
 
     // Add timesteps to the model
     for (int t = 0; t < 52; ++t) {

--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -72,6 +72,7 @@ classDiagram
         +Timestep(const Timestep &&)
         +operator=(const Timestep &&) Timestep &
         +CreateTransition(const string &) const unique_ptr~Transition~ &
+        +AddTransition(const unique_ptr~Transition~ &)
         +RemoveTransition(size_t) unique_ptr~Transition~
         +AddMatrixToTransition(const size_t &, const Ref~const MatrixXd~ &)
         +AddMatrixToTransition(const string &, const Ref~const MatrixXd~ &)
@@ -79,6 +80,8 @@ classDiagram
         +GetTransition(const string &) const unique_ptr~Transition~ &
         +GetTransitions() vector~unique_ptr~Transition~~
         +GetTransitionNames() vector~string~
+        +operator[](size_t) TransitionSlotProxy
+        +operator[](size_t) const Transition &
         +operator<<(ostream &os, const Timestep &obj) ostream &
         +operator==(const Timestep &, const Timestep &) bool
         +operator!=(const Timestep &, const Timestep &) bool

--- a/include/respond/timestep.hpp
+++ b/include/respond/timestep.hpp
@@ -181,6 +181,13 @@ public:
         return _transitions.back();
     }
 
+    /// @brief Adds a transition to the timestep.
+    /// The transition is cloned and managed by the timestep.
+    /// @param transition A unique_ptr to a Transition instance to add.
+    void AddTransition(const std::unique_ptr<Transition> &transition) {
+        _transitions.push_back(transition->clone());
+    }
+
     /// @brief Removes a transition from this timestep by index and returns it.
     /// @param idx The index of the transition to remove. Must be within the
     /// range of existing transitions.

--- a/include/respond/timestep.hpp
+++ b/include/respond/timestep.hpp
@@ -4,7 +4,7 @@
 // Created Date: 2026-06-30                                                   //
 // Author: Matthew Carroll                                                    //
 // -----                                                                      //
-// Last Modified: 2026-07-16                                                  //
+// Last Modified: 2026-07-23                                                  //
 // Modified By: Matthew Carroll                                               //
 // -----                                                                      //
 // Copyright (c) 2026 Syndemics Lab at Boston Medical Center                  //
@@ -29,6 +29,61 @@ namespace respond {
 /// timestep also handles logging for its operations.
 class Timestep {
 public:
+    /// @brief Proxy for mutable model slot access with clone-based assignment.
+    class TransitionSlotProxy {
+    public:
+        TransitionSlotProxy(Timestep &owner, size_t idx)
+            : _owner(&owner), _idx(idx) {}
+
+        /// @brief Access the underlying model pointer for member access.
+        Transition *operator->() {
+            return &_owner->GetTransitionRefOrThrow(_idx);
+        }
+
+        /// @brief Dereference to the underlying model.
+        Transition &operator*() {
+            return _owner->GetTransitionRefOrThrow(_idx);
+        }
+
+        /// @brief Implicit conversion to underlying mutable model reference.
+        operator Transition &() {
+            return _owner->GetTransitionRefOrThrow(_idx);
+        }
+
+        /// @brief Replace this slot by cloning from another proxy's model.
+        TransitionSlotProxy &operator=(const TransitionSlotProxy &other) {
+            return *this = static_cast<const Transition &>(
+                       other._owner->GetTransitionRefOrThrow(other._idx));
+        }
+
+        /// @brief Replace this slot by cloning from a model reference.
+        TransitionSlotProxy &operator=(const Transition &transition) {
+            _owner->GetTransitionRefOrThrow(_idx);
+            _owner->_transitions[_idx] = transition.clone();
+            return *this;
+        }
+
+        /// @brief Replace this slot by cloning from a model unique_ptr.
+        /// @throws std::invalid_argument if model is nullptr.
+        TransitionSlotProxy &
+        operator=(const std::unique_ptr<Transition> &transition) {
+            if (!transition) {
+                LogError(_owner->_log_name,
+                         "Cannot assign null model pointer to simulation "
+                         "slot.");
+                throw std::invalid_argument(
+                    "Error attempting to assign null model pointer.");
+            }
+            _owner->GetTransitionRefOrThrow(_idx);
+            _owner->_transitions[_idx] = transition->clone();
+            return *this;
+        }
+
+    private:
+        Timestep *_owner;
+        size_t _idx;
+    };
+
     ////////////////////////////////////////////////////////////////////////////
     //
     // Rule of Five: Copy and Move Semantics
@@ -247,6 +302,25 @@ public:
     //
     ////////////////////////////////////////////////////////////////////////////
 
+    /// @brief Mutable index-based transition access.
+    /// @details Returns a proxy that supports both transition member access and
+    /// clone-based replacement assignment.
+    /// @param idx The index of the transition to access.
+    /// @return A mutable proxy for the transition slot.
+    /// @throws std::out_of_range if idx is out of range.
+    TransitionSlotProxy operator[](size_t idx) {
+        GetTransitionRefOrThrow(idx);
+        return TransitionSlotProxy(*this, idx);
+    }
+
+    /// @brief Const index-based transition access.
+    /// @param idx The index of the transition to access.
+    /// @return Const reference to the transition at the index.
+    /// @throws std::out_of_range if idx is out of range.
+    const Transition &operator[](size_t idx) const {
+        return GetTransitionRefOrThrow(idx);
+    }
+
     /// @brief Overloaded stream insertion operator for Timestep. Outputs the
     /// names of all transitions in the timestep to the provided output stream.
     /// @details This operator allows for easy logging and debugging of the
@@ -305,6 +379,26 @@ public:
     bool operator!=(const Timestep &other) const { return !(*this == other); }
 
 private:
+    Transition &GetTransitionRefOrThrow(size_t idx) {
+        if (idx >= _transitions.size()) {
+            LogError(_log_name, "Index out of range in transition access: " +
+                                    std::to_string(idx));
+            throw std::out_of_range("Error attempting to access transition by "
+                                    "index.");
+        }
+        return *_transitions[idx];
+    }
+
+    const Transition &GetTransitionRefOrThrow(size_t idx) const {
+        if (idx >= _transitions.size()) {
+            LogError(_log_name, "Index out of range in transition access: " +
+                                    std::to_string(idx));
+            throw std::out_of_range("Error attempting to access transition by "
+                                    "index.");
+        }
+        return *_transitions[idx];
+    }
+
     std::string _log_name;
     std::vector<std::unique_ptr<Transition>> _transitions;
 };

--- a/tests/unit/timestep_test.cpp
+++ b/tests/unit/timestep_test.cpp
@@ -76,6 +76,30 @@ TEST_F(TimestepTest, CreateTransition) {
     ASSERT_EQ(transition->GetName(), "migration");
 }
 
+TEST_F(TimestepTest, AddTransitionClonesInputTransition) {
+    Timestep ts("test_log", test_log_file_);
+
+    auto transition =
+        Transition::Create("migration", "migration", "test_log", test_log_file_);
+
+    Eigen::MatrixXd m1(2, 2);
+    m1 << 0.5, 0.5, 0.5, 0.5;
+    transition->AddMatrix(m1);
+
+    ts.AddTransition(transition);
+
+    // Mutating the caller-owned transition should not affect timestep-owned
+    // clone.
+    Eigen::MatrixXd m2(2, 2);
+    m2 << 0.1, 0.9, 0.2, 0.8;
+    transition->AddMatrix(m2);
+
+    const std::unique_ptr<Transition> &stored = ts.GetTransition(0);
+    ASSERT_EQ(stored->GetName(), "migration");
+    ASSERT_EQ(stored->GetMatrices().size(), 1);
+    ASSERT_TRUE(stored->GetMatrices()[0].isApprox(m1));
+}
+
 TEST_F(TimestepTest, AddMatrixToTransitionByIndex) {
     Timestep ts("test_log", test_log_file_);
     const std::unique_ptr<Transition> &transition =
@@ -164,6 +188,42 @@ TEST_F(TimestepTest, CopyAssignment) {
     std::vector<std::string> names = ts2.GetTransitionNames();
     ASSERT_EQ(names.size(), 1);
     ASSERT_EQ(names[0], "migration");
+}
+
+TEST_F(TimestepTest, MutableOperatorIndexProvidesTransitionAccess) {
+    Timestep ts("test_log", test_log_file_);
+    ts.CreateTransition("migration");
+
+    Eigen::MatrixXd m(2, 2);
+    m << 0.4, 0.6, 0.1, 0.9;
+
+    ts[0]->AddMatrix(m);
+
+    ASSERT_EQ(ts.GetTransition(0)->GetMatrices().size(), 1);
+    ASSERT_TRUE(ts.GetTransition(0)->GetMatrices()[0].isApprox(m));
+}
+
+TEST_F(TimestepTest, MutableOperatorIndexSupportsSlotReplacementAssignment) {
+    Timestep ts("test_log", test_log_file_);
+    ts.CreateTransition("migration");
+    ts.CreateTransition("behavior");
+
+    ts[0] = ts[1];
+    ASSERT_EQ(ts.GetTransition(0)->GetName(), "behavior");
+
+    auto overdose =
+        Transition::Create("overdose", "overdose", "test_log", test_log_file_);
+    ts[1] = overdose;
+    ASSERT_EQ(ts.GetTransition(1)->GetName(), "overdose");
+}
+
+TEST_F(TimestepTest, ConstOperatorIndexReturnsConstTransitionReference) {
+    Timestep ts("test_log", test_log_file_);
+    ts.CreateTransition("migration");
+
+    const Timestep &const_ts = ts;
+    const Transition &transition = const_ts[0];
+    ASSERT_EQ(transition.GetName(), "migration");
 }
 
 TEST_F(TimestepTest, StreamOperatorOverload) {


### PR DESCRIPTION
## What does this PR do?

This PR adds similar behavior to the Timestep class as was recently added to Simulation. We now have the ability to control `Transitions` via the indexing operator overload. Additionally we now have an `AddTransition` method to help facilitate easier creation.

## What Wrike task is this associated with?

## Checklist before merging

- [x] If adding a core feature, I've added related tests.
- [x] This is part of a [product update](https://www.chameleon.io/blog/product-updates), and I've added an explanation of what is different to the changelog.
